### PR TITLE
ci: build against go 1.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
           - "^1.14"
           - "^1.15"
           - "^1.16"
+          - "^1.17"
     steps:
       - name: Setup Go
         uses: actions/setup-go@v2


### PR DESCRIPTION
not removing support for go 1.14 for now

Signed-off-by: nscuro <nscuro@protonmail.com>