### PR TITLE
build(ci): add license header check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,18 @@ on:
       - master
 
 jobs:
-  golangci:
+  licensecheck:
+    name: License Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Check license headers
+        uses: apache/skywalking-eyes@v0.2.0
+        with:
+          config: .licenserc.yml
+
+  lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
@@ -45,8 +56,3 @@ jobs:
         uses: actions/checkout@v2
       - name: Test
         run: make test
-      - name: Generate SBOM
-        uses: CycloneDX/gh-gomod-generate-sbom@v1
-        with:
-          version: v1
-          args: mod -licenses -json -type library -verbose

--- a/.licenserc.yml
+++ b/.licenserc.yml
@@ -1,0 +1,19 @@
+header:
+  license:
+    spdx-id: Apache-2.0
+    copyright-owner: OWASP Foundation
+  paths-ignore:
+    - ".github/**"
+    - ".gitignore"
+    - ".gitpod.*"
+    - ".golangci.yml"
+    - ".goreleaser.yml"
+    - ".licenserc.yml"
+    - "**/*.md"
+    - "**/go.mod"
+    - "**/go.sum"
+    - "**/testdata/**"
+    - "CODEOWNERS"
+    - "LICENSE"
+    - "Makefile"
+    - "NOTICE"

--- a/example_test.go
+++ b/example_test.go
@@ -1,3 +1,20 @@
+// This file is part of CycloneDX Go
+//
+// Licensed under the Apache License, Version 2.0 (the “License”);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an “AS IS” BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OWASP Foundation. All Rights Reserved.
+
 package cyclonedx_test
 
 import (


### PR DESCRIPTION
also remove sbom generation from ci workflow, it doesn't serve any purpose

Signed-off-by: nscuro <nscuro@protonmail.com>