### PR TITLE
fix: encoding of XML chars in tags

### DIFF
--- a/cyclonedx.go
+++ b/cyclonedx.go
@@ -49,7 +49,7 @@ type Affects struct {
 }
 
 type AttachedText struct {
-	Content     string `json:"content" xml:",innerxml"`
+	Content     string `json:"content" xml:",chardata"`
 	ContentType string `json:"contentType,omitempty" xml:"content-type,attr,omitempty"`
 	Encoding    string `json:"encoding,omitempty" xml:"encoding,attr,omitempty"`
 }
@@ -205,7 +205,7 @@ type Credits struct {
 
 type DataClassification struct {
 	Flow           DataFlow `json:"flow" xml:"flow,attr"`
-	Classification string   `json:"classification" xml:",innerxml"`
+	Classification string   `json:"classification" xml:",chardata"`
 }
 
 type DataFlow string
@@ -308,7 +308,7 @@ const (
 
 type Hash struct {
 	Algorithm HashAlgorithm `json:"alg" xml:"alg,attr"`
-	Value     string        `json:"content" xml:",innerxml"`
+	Value     string        `json:"content" xml:",chardata"`
 }
 
 type HashAlgorithm string
@@ -517,7 +517,7 @@ type Pedigree struct {
 
 type Property struct {
 	Name  string `json:"name" xml:"name,attr"`
-	Value string `json:"value" xml:",innerxml"`
+	Value string `json:"value" xml:",chardata"`
 }
 
 type ReleaseNotes struct {

--- a/encode_test.go
+++ b/encode_test.go
@@ -73,6 +73,16 @@ func TestXmlBOMEncoder_SetPretty(t *testing.T) {
 				Name: "authorName",
 			},
 		},
+		Properties: &[]Property{
+			{
+				Name:  "XML",
+				Value: "<xml>in here</xml>",
+			},
+			{
+				Name:  "Specials",
+				Value: "Special chars: < & > \"",
+			},
+		},
 	}
 
 	require.NoError(t, encoder.Encode(bom))
@@ -85,6 +95,10 @@ func TestXmlBOMEncoder_SetPretty(t *testing.T) {
         <name>authorName</name>
       </author>
     </authors>
+    <properties>
+      <property name="XML">&lt;xml&gt;in here&lt;/xml&gt;</property>
+      <property name="Specials">Special chars: &lt; &amp; &gt; &#34;</property>
+    </properties>
   </metadata>
 </bom>`, buf.String())
 }


### PR DESCRIPTION
Property and other items were encoded as `innerxml` instead of
`chardata`. Innerxml does not encode special XML chars.

See also: https://github.com/golang/go/issues/16604

Fixes #31