### PR TITLE
feat: add JSON Schema to JSON output

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -78,6 +78,7 @@ func (b *BOM) convert(specVersion SpecVersion) {
 
 	b.SpecVersion = specVersion
 	b.XMLNS = xmlNamespaces[specVersion]
+	b.JSONSchema = jsonSchemas[specVersion]
 }
 
 // componentConverter modifies a Component such that it adheres to a given SpecVersion.

--- a/cyclonedx.go
+++ b/cyclonedx.go
@@ -60,6 +60,7 @@ type BOM struct {
 	XMLNS   string   `json:"-" xml:"xmlns,attr"`
 
 	// JSON specific fields
+	JSONSchema  string      `json:"$schema,omitempty" xml:"-"`
 	BOMFormat   string      `json:"bomFormat" xml:"-"`
 	SpecVersion SpecVersion `json:"specVersion" xml:"-"`
 
@@ -77,6 +78,7 @@ type BOM struct {
 
 func NewBOM() *BOM {
 	return &BOM{
+		JSONSchema:  jsonSchemas[SpecVersion1_4],
 		XMLNS:       xmlNamespaces[SpecVersion1_4],
 		BOMFormat:   BOMFormat,
 		SpecVersion: SpecVersion1_4,

--- a/cyclonedx_json.go
+++ b/cyclonedx_json.go
@@ -49,3 +49,11 @@ func (sv *SpecVersion) UnmarshalJSON(bytes []byte) error {
 
 	return nil
 }
+
+var jsonSchemas = map[SpecVersion]string{
+	SpecVersion1_0: "",
+	SpecVersion1_1: "",
+	SpecVersion1_2: "http://cyclonedx.org/schema/bom-1.2.schema.json",
+	SpecVersion1_3: "http://cyclonedx.org/schema/bom-1.3.schema.json",
+	SpecVersion1_4: "http://cyclonedx.org/schema/bom-1.4.schema.json",
+}

--- a/encode_test.go
+++ b/encode_test.go
@@ -51,6 +51,7 @@ func TestJsonBOMEncoder_SetPretty(t *testing.T) {
 	require.NoError(t, encoder.Encode(bom))
 
 	assert.Equal(t, `{
+  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
@@ -83,6 +84,7 @@ func TestJsonBOMEncoder_SetEscapeHTML_true(t *testing.T) {
 	require.NoError(t, encoder.Encode(bom))
 
 	assert.Equal(t, `{
+  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
@@ -115,6 +117,7 @@ func TestJsonBOMEncoder_SetEscapeHTML_false(t *testing.T) {
 	require.NoError(t, encoder.Encode(bom))
 
 	assert.Equal(t, `{
+  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,

--- a/testdata/snapshots/cyclonedx-go-TestJsonBOMEncoder_EncodeVersion-func3-1.2.bom.json
+++ b/testdata/snapshots/cyclonedx-go-TestJsonBOMEncoder_EncodeVersion-func3-1.2.bom.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.2.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.2",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/testdata/snapshots/cyclonedx-go-TestJsonBOMEncoder_EncodeVersion-func3-1.3.bom.json
+++ b/testdata/snapshots/cyclonedx-go-TestJsonBOMEncoder_EncodeVersion-func3-1.3.bom.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.3.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.3",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",

--- a/testdata/snapshots/cyclonedx-go-TestJsonBOMEncoder_EncodeVersion-func3-1.4.bom.json
+++ b/testdata/snapshots/cyclonedx-go-TestJsonBOMEncoder_EncodeVersion-func3-1.4.bom.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",


### PR DESCRIPTION
This adds a `$schema` field to the JSON output, to achieve parity with the CycloneDX JavaScript library. The value points to the JSON schema definition file at cyclonedx.org.