### PR TITLE
fix: unmarshal bom on v1.5 return invalid specification version

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -277,6 +277,8 @@ func (sv SpecVersion) supportsComponentType(cType ComponentType) bool {
 		return sv >= SpecVersion1_1
 	case ComponentTypeContainer, ComponentTypeFirmware:
 		return sv >= SpecVersion1_2
+	case ComponentTypeData, ComponentTypeDeviceDriver, ComponentTypeMachineLearningModel, ComponentTypePlatform:
+		return sv >= SpecVersion1_5
 	}
 
 	return false

--- a/cyclonedx.go
+++ b/cyclonedx.go
@@ -103,14 +103,18 @@ type BOMReference string
 type ComponentType string
 
 const (
-	ComponentTypeApplication ComponentType = "application"
-	ComponentTypeContainer   ComponentType = "container"
-	ComponentTypeDevice      ComponentType = "device"
-	ComponentTypeFile        ComponentType = "file"
-	ComponentTypeFirmware    ComponentType = "firmware"
-	ComponentTypeFramework   ComponentType = "framework"
-	ComponentTypeLibrary     ComponentType = "library"
-	ComponentTypeOS          ComponentType = "operating-system"
+	ComponentTypeApplication          ComponentType = "application"
+	ComponentTypeContainer            ComponentType = "container"
+	ComponentTypeData                 ComponentType = "data"
+	ComponentTypeDevice               ComponentType = "device"
+	ComponentTypeDeviceDriver         ComponentType = "device-driver"
+	ComponentTypeFile                 ComponentType = "file"
+	ComponentTypeFirmware             ComponentType = "firmware"
+	ComponentTypeFramework            ComponentType = "framework"
+	ComponentTypeLibrary              ComponentType = "library"
+	ComponentTypeMachineLearningModel ComponentType = "machine-learning-model"
+	ComponentTypeOS                   ComponentType = "operating-system"
+	ComponentTypePlatform             ComponentType = "platform"
 )
 
 type Commit struct {

--- a/cyclonedx_json.go
+++ b/cyclonedx_json.go
@@ -43,6 +43,8 @@ func (sv *SpecVersion) UnmarshalJSON(bytes []byte) error {
 		*sv = SpecVersion1_3
 	case SpecVersion1_4.String():
 		*sv = SpecVersion1_4
+	case SpecVersion1_5.String():
+		*sv = SpecVersion1_5
 	default:
 		return ErrInvalidSpecVersion
 	}

--- a/cyclonedx_xml.go
+++ b/cyclonedx_xml.go
@@ -183,6 +183,8 @@ func (sv *SpecVersion) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 		*sv = SpecVersion1_3
 	case SpecVersion1_4.String():
 		*sv = SpecVersion1_4
+	case SpecVersion1_5.String():
+		*sv = SpecVersion1_5
 	default:
 		return ErrInvalidSpecVersion
 	}


### PR DESCRIPTION
## Description:
unmarshal bom on v1.5 return invalid specification version

Close: #101 