### PR TITLE
fix: unmarshal bom on v1.5 return invalid specification version

### DIFF
--- a/cyclonedx_json.go
+++ b/cyclonedx_json.go
@@ -43,6 +43,8 @@ func (sv *SpecVersion) UnmarshalJSON(bytes []byte) error {
 		*sv = SpecVersion1_3
 	case SpecVersion1_4.String():
 		*sv = SpecVersion1_4
+	case SpecVersion1_5.String():
+		*sv = SpecVersion1_5
 	default:
 		return ErrInvalidSpecVersion
 	}

--- a/cyclonedx_xml.go
+++ b/cyclonedx_xml.go
@@ -183,6 +183,8 @@ func (sv *SpecVersion) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 		*sv = SpecVersion1_3
 	case SpecVersion1_4.String():
 		*sv = SpecVersion1_4
+	case SpecVersion1_5.String():
+		*sv = SpecVersion1_5
 	default:
 		return ErrInvalidSpecVersion
 	}


### PR DESCRIPTION
## Description:
unmarshal bom on v1.5 return invalid specification version

Close: #101 