### PR TITLE
ci: enable more linters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,12 @@ jobs:
       with:
         go-version: "1.20"
         check-latest: true
+        cache: false
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # tag=v3.7.0
       with:
         version: latest
+        args: --verbose
 
   test:
     name: Test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,16 @@
 linters:
   enable:
     - asciicheck
-    - gofmt
+    - errorlint
+    - gci
+    - gofumpt
     - gosec
     - wastedassign
+
+linters-settings:
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/CycloneDX)
+    custom-order: true

--- a/cyclonedx_xml.go
+++ b/cyclonedx_xml.go
@@ -52,7 +52,7 @@ func (c *Copyright) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	if err := d.DecodeElement(&text, &start); err != nil {
 		return err
 	}
-	(*c).Text = text
+	c.Text = text
 	return nil
 }
 

--- a/validate_json_test.go
+++ b/validate_json_test.go
@@ -19,6 +19,7 @@ package cyclonedx
 
 import (
 	"fmt"
+
 	"github.com/xeipuuv/gojsonschema"
 )
 
@@ -29,8 +30,7 @@ var jsonSchemaFiles = map[SpecVersion]string{
 	SpecVersion1_5: "file://./schema/bom-1.5.schema.json",
 }
 
-type jsonValidator struct {
-}
+type jsonValidator struct{}
 
 func newJSONValidator() validator {
 	return &jsonValidator{}

--- a/validate_xml_test.go
+++ b/validate_xml_test.go
@@ -19,8 +19,9 @@ package cyclonedx
 
 import (
 	"fmt"
-	"github.com/terminalstatic/go-xsd-validate"
 	"sync"
+
+	"github.com/terminalstatic/go-xsd-validate"
 )
 
 var xmlSchemaFiles = map[SpecVersion]string{
@@ -34,8 +35,7 @@ var xmlSchemaFiles = map[SpecVersion]string{
 
 var xsdValidateInitOnce sync.Once
 
-type xmlValidator struct {
-}
+type xmlValidator struct{}
 
 func newXMLValidator() validator {
 	var initErr error


### PR DESCRIPTION
Enables errorlint and gci.
It replaces gofmt by gofumpt as it is an extension. 
Disable setup-go cache to benefit from the golangci-lint-action’s cache.

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>