### PR TITLE
feat(1.6): extend EvidenceOccurrence

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -123,7 +123,6 @@ func componentConverter(specVersion SpecVersion) func(*Component) {
 		}
 
 		if specVersion < SpecVersion1_3 {
-			c.Evidence = nil
 			c.Properties = nil
 		}
 
@@ -137,22 +136,48 @@ func componentConverter(specVersion SpecVersion) func(*Component) {
 		if specVersion < SpecVersion1_5 {
 			c.ModelCard = nil
 			c.Data = nil
-
-			if c.Evidence != nil {
-				c.Evidence.Identity = nil
-				c.Evidence.Occurrences = nil
-				c.Evidence.Callstack = nil
-			}
 		}
 
 		if !specVersion.supportsComponentType(c.Type) {
 			c.Type = ComponentTypeApplication
 		}
+
 		convertExternalReferences(c.ExternalReferences, specVersion)
 		convertHashes(c.Hashes, specVersion)
 		convertLicenses(c.Licenses, specVersion)
+		convertEvidence(c, specVersion)
+
 		if !specVersion.supportsScope(c.Scope) {
 			c.Scope = ""
+		}
+	}
+}
+
+func convertEvidence(c *Component, specVersion SpecVersion) {
+	if c.Evidence == nil {
+		return
+	}
+
+	if specVersion < SpecVersion1_3 {
+		c.Evidence = nil
+		return
+	}
+
+	if specVersion < SpecVersion1_5 {
+		c.Evidence.Identity = nil
+		c.Evidence.Occurrences = nil
+		c.Evidence.Callstack = nil
+		return
+	}
+
+	for i := range *c.Evidence.Occurrences {
+		occ := &(*c.Evidence.Occurrences)[i]
+
+		if specVersion < SpecVersion1_6 {
+			occ.Line = nil
+			occ.Offset = nil
+			occ.Symbol = ""
+			occ.AdditionalContext = ""
 		}
 	}
 }

--- a/convert_test.go
+++ b/convert_test.go
@@ -1,0 +1,71 @@
+package cyclonedx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_componentConverter_convertEvidence(t *testing.T) {
+	t.Run("spec 1.2 and lower", func(t *testing.T) {
+		convert := componentConverter(SpecVersion1_2)
+
+		comp := Component{
+			Evidence: &Evidence{},
+		}
+
+		convert(&comp)
+
+		assert.Nil(t, comp.Evidence)
+	})
+
+	t.Run("spec 1.4 and lower", func(t *testing.T) {
+		convert := componentConverter(SpecVersion1_4)
+
+		comp := Component{
+			Evidence: &Evidence{
+				Identity:    &EvidenceIdentity{},
+				Occurrences: &[]EvidenceOccurrence{},
+				Callstack:   &Callstack{},
+				Copyright:   &[]Copyright{{Text: "foo"}},
+			},
+		}
+
+		convert(&comp)
+
+		assert.Nil(t, comp.Evidence.Identity)
+		assert.Nil(t, comp.Evidence.Occurrences)
+		assert.Nil(t, comp.Evidence.Callstack)
+		assert.NotNil(t, comp.Evidence.Copyright)
+	})
+
+	t.Run("spec 1.5 and lower", func(t *testing.T) {
+		convert := componentConverter(SpecVersion1_5)
+		var val int = 42
+
+		comp := Component{
+			Evidence: &Evidence{
+				Occurrences: &[]EvidenceOccurrence{
+					{
+						BOMRef:            "foo",
+						Location:          "bar",
+						Line:              &val,
+						Offset:            &val,
+						Symbol:            "asdf",
+						AdditionalContext: "quux",
+					},
+				},
+			},
+		}
+
+		convert(&comp)
+
+		require.Len(t, *comp.Evidence.Occurrences, 1)
+		occ := (*comp.Evidence.Occurrences)[0]
+		assert.Nil(t, occ.Line)
+		assert.Nil(t, occ.Offset)
+		assert.Zero(t, occ.Symbol)
+		assert.Zero(t, occ.AdditionalContext)
+	})
+}

--- a/cyclonedx.go
+++ b/cyclonedx.go
@@ -356,8 +356,12 @@ const (
 )
 
 type EvidenceOccurrence struct {
-	BOMRef   string `json:"bom-ref,omitempty" xml:"bom-ref,attr,omitempty"`
-	Location string `json:"location,omitempty" xml:"location,omitempty"`
+	BOMRef            string `json:"bom-ref,omitempty" xml:"bom-ref,attr,omitempty"`
+	Location          string `json:"location,omitempty" xml:"location,omitempty"`
+	Line              *int   `json:"line,omitempty" xml:"line,attr,omitempty"`
+	Offset            *int   `json:"offset,omitempty" xml:"offset,attr,omitempty"`
+	Symbol            string `json:"symbol,omitempty" xml:"symbol,attr,omitempty"`
+	AdditionalContext string `json:"additionalContext,omitempty" xml:"additionalContext,attr,omitempty"`
 }
 
 type ExternalReference struct {


### PR DESCRIPTION
This extends type `EvidenceOccurrence` with additional fields from the 1.6 spec. Logic has been added to the conversion to make sure they don't show up in lower spec versions.

Closes #156.