### PR TITLE
fix(1.6): fix json, xml labels on BOM.Definitions

### DIFF
--- a/cyclonedx.go
+++ b/cyclonedx.go
@@ -91,7 +91,7 @@ type BOM struct {
 	Vulnerabilities    *[]Vulnerability     `json:"vulnerabilities,omitempty" xml:"vulnerabilities>vulnerability,omitempty"`
 	Annotations        *[]Annotation        `json:"annotations,omitempty" xml:"annotations>annotation,omitempty"`
 	Formulation        *[]Formula           `json:"formulation,omitempty" xml:"formulation>formula,omitempty"`
-	Definitions        *Definitions         `json:"definitions" xml:"definitions,omitempty"`
+	Definitions        *Definitions         `json:"definitions,omitempty" xml:"definitions,omitempty"`
 }
 
 func NewBOM() *BOM {
@@ -873,7 +873,7 @@ type StandardDefinition struct {
 
 	Requirements       *[]StandardRequirement `json:"requirements,omitempty" xml:"requirements>requirement,omitempty"`
 	Levels             *[]StandardLevel       `json:"levels,omitempty" xml:"levels>level,omitempty"`
-	ExternalReferences *[]ExternalReference   `json:"externalReferences,omitempty" xml:"externalReferences,omitempty"`
+	ExternalReferences *[]ExternalReference   `json:"externalReferences,omitempty" xml:"externalReferences>reference,omitempty"`
 	Signature          *JSFSignature          `json:"signature,omitempty" xml:"-"`
 }
 

--- a/testdata/snapshots/cyclonedx-go-TestRoundTripJSON-func1-valid-definitions.json
+++ b/testdata/snapshots/cyclonedx-go-TestRoundTripJSON-func1-valid-definitions.json
@@ -1,0 +1,24 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "std-ref-1",
+        "name": "CycloneDX",
+        "version": "1.6",
+        "description": "A full-stack Bill of Materials standard that provides advanced supply chain capabilities for cyber risk reduction.",
+        "owner": "OWASP",
+        "externalReferences": [
+          {
+            "url": "https://cyclonedx.org",
+            "type": "website"
+          }
+        ]
+      }
+    ]
+  }
+}
+

--- a/testdata/snapshots/cyclonedx-go-TestRoundTripXML-func1-valid-definitions.xml
+++ b/testdata/snapshots/cyclonedx-go-TestRoundTripXML-func1-valid-definitions.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1">
+  <definitions>
+    <standards>
+      <standard bom-ref="std-ref-1">
+        <name>CycloneDX</name>
+        <version>1.6</version>
+        <description>A full-stack Bill of Materials standard that provides advanced supply chain capabilities for cyber risk reduction.</description>
+        <owner>OWASP</owner>
+        <externalReferences>
+          <reference type="website">
+            <url>https://cyclonedx.org</url>
+          </reference>
+        </externalReferences>
+      </standard>
+    </standards>
+  </definitions>
+</bom>

--- a/testdata/valid-definitions.json
+++ b/testdata/valid-definitions.json
@@ -1,0 +1,23 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "std-ref-1",
+        "name": "CycloneDX",
+        "version": "1.6",
+        "description": "A full-stack Bill of Materials standard that provides advanced supply chain capabilities for cyber risk reduction.",
+        "owner": "OWASP",
+        "externalReferences": [
+          {
+            "type": "website",
+            "url": "https://cyclonedx.org"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/testdata/valid-definitions.xml
+++ b/testdata/valid-definitions.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<bom serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1" xmlns="http://cyclonedx.org/schema/bom/1.6">
+    <definitions>
+        <standards>
+            <standard bom-ref="std-ref-1">
+                <name>CycloneDX</name>
+                <version>1.6</version>
+                <description>A full-stack Bill of Materials standard that provides advanced supply chain capabilities for cyber risk reduction.</description>
+                <owner>OWASP</owner>
+                <externalReferences>
+                    <reference type="website">
+                        <url>https://cyclonedx.org</url>
+                    </reference>
+                </externalReferences>
+            </standard>
+        </standards>
+    </definitions>
+</bom>


### PR DESCRIPTION
This adds roundtrip tests for `BOM.Definitions` (added in #161) and fixes some mistakes on JSON, XML labels along the way.