### PR TITLE
fix(1.6): convert occurrences of OrganizationalEntity

### DIFF
--- a/convert_test.go
+++ b/convert_test.go
@@ -93,3 +93,66 @@ func Test_convertLicenses(t *testing.T) {
 		assert.Zero(t, (*(*bom.Components)[0].Licenses)[0].License.Acknowledgement)
 	})
 }
+
+func Test_convertTools_OrganizationalEntity(t *testing.T) {
+	t.Run("spec 1.5 and lower", func(t *testing.T) {
+		orgStub := func() *OrganizationalEntity {
+			t.Helper()
+			return &OrganizationalEntity{
+				Name:    "Acme Corp",
+				Address: &PostalAddress{},
+			}
+		}
+
+		bom := NewBOM()
+		bom.Metadata = &Metadata{
+			Manufacture: orgStub(),
+			Supplier:    orgStub(),
+			Tools: &ToolsChoice{
+				Services: &[]Service{{Provider: orgStub()}},
+			},
+			Licenses: &Licenses{
+				{
+					License: &License{
+						Licensing: &Licensing{
+							Licensor:  &OrganizationalEntityOrContact{Organization: orgStub()},
+							Licensee:  &OrganizationalEntityOrContact{Organization: orgStub()},
+							Purchaser: &OrganizationalEntityOrContact{Organization: orgStub()},
+						},
+					},
+				},
+			},
+		}
+		bom.Vulnerabilities = &[]Vulnerability{
+			{
+				ID: "some-vuln",
+				Credits: &Credits{
+					Organizations: &[]OrganizationalEntity{*orgStub()},
+				},
+			},
+		}
+		bom.Annotations = &[]Annotation{
+			{
+				Annotator: &Annotator{
+					Organization: orgStub(),
+					Service:      &Service{Provider: orgStub()},
+				},
+			},
+		}
+
+		bom.convert(SpecVersion1_5)
+
+		assert.Nil(t, bom.Metadata.Manufacture.Address)
+		assert.Nil(t, bom.Metadata.Supplier.Address)
+		assert.Nil(t, (*bom.Metadata.Tools.Services)[0].Provider.Address)
+
+		assert.Nil(t, (*bom.Metadata.Licenses)[0].License.Licensing.Licensor.Organization.Address)
+		assert.Nil(t, (*bom.Metadata.Licenses)[0].License.Licensing.Licensee.Organization.Address)
+		assert.Nil(t, (*bom.Metadata.Licenses)[0].License.Licensing.Purchaser.Organization.Address)
+
+		assert.Nil(t, (*(*bom.Vulnerabilities)[0].Credits.Organizations)[0].Address)
+
+		assert.Nil(t, (*bom.Annotations)[0].Annotator.Organization.Address)
+		assert.Nil(t, (*bom.Annotations)[0].Annotator.Service.Provider.Address)
+	})
+}


### PR DESCRIPTION
This adds `func convertOrganizationalEntity()` and targets occurences of `OrganizationalEntity` during spec conversion. This is an addendum to #173.

Closes #174.