### PR TITLE
Adds missing BOMRef on OrganizationalEntity & OrganizationalContact

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -71,6 +71,12 @@ func (b *BOM) convert(specVersion SpecVersion) {
 		convertTools(b.Metadata.Tools, specVersion)
 		convertOrganizationalEntity(b.Metadata.Manufacture, specVersion)
 		convertOrganizationalEntity(b.Metadata.Supplier, specVersion)
+
+		if b.Metadata.Authors != nil {
+			for i := range *b.Metadata.Authors {
+				convertOrganizationalContact(&(*b.Metadata.Authors)[i], specVersion)
+			}
+		}
 	}
 
 	if b.Components != nil {
@@ -324,8 +330,28 @@ func convertOrganizationalEntity(org *OrganizationalEntity, specVersion SpecVers
 		return
 	}
 
+	if specVersion < SpecVersion1_5 {
+		org.BOMRef = ""
+
+		if org.Contact != nil {
+			for i := range *org.Contact {
+				convertOrganizationalContact(&(*org.Contact)[i], specVersion)
+			}
+		}
+	}
+
 	if specVersion < SpecVersion1_6 {
 		org.Address = nil
+	}
+}
+
+func convertOrganizationalContact(c *OrganizationalContact, specVersion SpecVersion) {
+	if c == nil {
+		return
+	}
+
+	if specVersion < SpecVersion1_5 {
+		c.BOMRef = ""
 	}
 }
 
@@ -362,6 +388,12 @@ func convertVulnerabilities(vulns *[]Vulnerability, specVersion SpecVersion) {
 				if vuln.Credits.Organizations != nil {
 					for i := range *vuln.Credits.Organizations {
 						convertOrganizationalEntity(&(*vuln.Credits.Organizations)[i], specVersion)
+					}
+				}
+
+				if vuln.Credits.Individuals != nil {
+					for i := range *vuln.Credits.Individuals {
+						convertOrganizationalContact(&(*vuln.Credits.Individuals)[i], specVersion)
 					}
 				}
 			}

--- a/cyclonedx.go
+++ b/cyclonedx.go
@@ -1124,12 +1124,14 @@ type Note struct {
 }
 
 type OrganizationalContact struct {
-	Name  string `json:"name,omitempty" xml:"name,omitempty"`
-	Email string `json:"email,omitempty" xml:"email,omitempty"`
-	Phone string `json:"phone,omitempty" xml:"phone,omitempty"`
+	BOMRef string `json:"bom-ref,omitempty" xml:"bom-ref,attr,omitempty"`
+	Name   string `json:"name,omitempty" xml:"name,omitempty"`
+	Email  string `json:"email,omitempty" xml:"email,omitempty"`
+	Phone  string `json:"phone,omitempty" xml:"phone,omitempty"`
 }
 
 type OrganizationalEntity struct {
+	BOMRef  string                   `json:"bom-ref,omitempty" xml:"bom-ref,attr,omitempty"`
 	Name    string                   `json:"name" xml:"name"`
 	Address *PostalAddress           `json:"address,omitempty" xml:"address,omitempty"`
 	URL     *[]string                `json:"url,omitempty" xml:"url,omitempty"`

--- a/testdata/snapshots/cyclonedx-go-TestRoundTripJSON-func1-valid-metadata-author.json
+++ b/testdata/snapshots/cyclonedx-go-TestRoundTripJSON-func1-valid-metadata-author.json
@@ -6,6 +6,7 @@
   "metadata": {
     "authors": [
       {
+        "bom-ref": "author-1",
         "name": "Samantha Wright",
         "email": "samantha.wright@example.com",
         "phone": "800-555-1212"

--- a/testdata/snapshots/cyclonedx-go-TestRoundTripJSON-func1-valid-metadata-manufacture.json
+++ b/testdata/snapshots/cyclonedx-go-TestRoundTripJSON-func1-valid-metadata-manufacture.json
@@ -5,12 +5,14 @@
   "version": 1,
   "metadata": {
     "manufacture": {
+      "bom-ref": "manufacture-1",
       "name": "Acme, Inc.",
       "url": [
         "https://example.com"
       ],
       "contact": [
         {
+          "bom-ref": "contact-1",
           "name": "Acme Professional Services",
           "email": "professional.services@example.com"
         }

--- a/testdata/snapshots/cyclonedx-go-TestRoundTripXML-func1-valid-metadata-author.xml
+++ b/testdata/snapshots/cyclonedx-go-TestRoundTripXML-func1-valid-metadata-author.xml
@@ -2,7 +2,7 @@
 <bom xmlns="http://cyclonedx.org/schema/bom/1.6" serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1">
   <metadata>
     <authors>
-      <author>
+      <author bom-ref="contact-1">
         <name>Samantha Wright</name>
         <email>samantha.wright@example.com</email>
         <phone>800-555-1212</phone>

--- a/testdata/snapshots/cyclonedx-go-TestRoundTripXML-func1-valid-metadata-manufacture.xml
+++ b/testdata/snapshots/cyclonedx-go-TestRoundTripXML-func1-valid-metadata-manufacture.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bom xmlns="http://cyclonedx.org/schema/bom/1.6" serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1">
   <metadata>
-    <manufacture>
+    <manufacture bom-ref="manufacture-1">
       <name>Acme, Inc.</name>
       <url>https://example.com</url>
-      <contact>
+      <contact bom-ref="contact-1">
         <name>Acme Professional Services</name>
         <email>professional.services@example.com</email>
       </contact>

--- a/testdata/valid-metadata-author.json
+++ b/testdata/valid-metadata-author.json
@@ -6,6 +6,7 @@
   "metadata": {
     "authors": [
       {
+        "bom-ref": "author-1",
         "name": "Samantha Wright",
         "email": "samantha.wright@example.com",
         "phone": "800-555-1212"

--- a/testdata/valid-metadata-author.xml
+++ b/testdata/valid-metadata-author.xml
@@ -2,7 +2,7 @@
 <bom serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1" xmlns="http://cyclonedx.org/schema/bom/1.6">
     <metadata>
         <authors>
-            <author>
+            <author bom-ref="contact-1">
                 <name>Samantha Wright</name>
                 <email>samantha.wright@example.com</email>
                 <phone>800-555-1212</phone>

--- a/testdata/valid-metadata-manufacture.json
+++ b/testdata/valid-metadata-manufacture.json
@@ -5,12 +5,14 @@
   "version": 1,
   "metadata": {
     "manufacture": {
+      "bom-ref": "manufacture-1",
       "name": "Acme, Inc.",
       "url": [
         "https://example.com"
       ],
       "contact": [
         {
+          "bom-ref": "contact-1",
           "name": "Acme Professional Services",
           "email": "professional.services@example.com"
         }

--- a/testdata/valid-metadata-manufacture.xml
+++ b/testdata/valid-metadata-manufacture.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <bom serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1" xmlns="http://cyclonedx.org/schema/bom/1.6">
     <metadata>
-        <manufacture>
+        <manufacture bom-ref="manufacture-1">
             <name>Acme, Inc.</name>
             <url>https://example.com</url>
-            <contact>
+            <contact bom-ref="contact-1">
                 <name>Acme Professional Services</name>
                 <email>professional.services@example.com</email>
             </contact>


### PR DESCRIPTION
Adds `BOMRef` to `OrganizationalEntity` [[1.5 spec](https://github.com/CycloneDX/specification/blob/master/schema/bom-1.5.schema.json#L363-L367)] & `OrganizationalContact` [[1.5 spec](https://github.com/CycloneDX/specification/blob/master/schema/bom-1.5.schema.json#L363-L367)] which were added in the CycloneDX 1.5 spec.

I've kept this in the `1.6` spec branch as additional conversation functions were added to handle `OrganizationalEntity`s and reduce merge conflicts.

Fixes issue: https://github.com/CycloneDX/cyclonedx-go/issues/180