### PR TITLE
fix: change `Component.Evidence.Identity` to array

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -195,6 +195,13 @@ func convertEvidence(c *Component, specVersion SpecVersion) {
 	}
 
 	if specVersion < SpecVersion1_6 {
+		// Spec version 1.5 uses only one Identity.
+		// cf. https://cyclonedx.org/docs/1.5/json/#components_items_evidence_identity
+		if c.Evidence.Identity != nil {
+			ids := *c.Evidence.Identity
+			ids = ids[:1]
+			c.Evidence.Identity = &ids
+		}
 		if c.Evidence.Occurrences != nil {
 			for i := range *c.Evidence.Occurrences {
 				occ := &(*c.Evidence.Occurrences)[i]

--- a/convert_test.go
+++ b/convert_test.go
@@ -42,7 +42,7 @@ func Test_componentConverter_convertEvidence(t *testing.T) {
 
 		comp := Component{
 			Evidence: &Evidence{
-				Identity:    &EvidenceIdentity{},
+				Identity:    &[]EvidenceIdentity{},
 				Occurrences: &[]EvidenceOccurrence{},
 				Callstack:   &Callstack{},
 				Copyright:   &[]Copyright{{Text: "foo"}},

--- a/convert_test.go
+++ b/convert_test.go
@@ -63,6 +63,14 @@ func Test_componentConverter_convertEvidence(t *testing.T) {
 
 		comp := Component{
 			Evidence: &Evidence{
+				Identity: &[]EvidenceIdentity{
+					{
+						Field: EvidenceIdentityFieldTypePURL,
+					},
+					{
+						Field: EvidenceIdentityFieldTypeName,
+					},
+				},
 				Occurrences: &[]EvidenceOccurrence{
 					{
 						BOMRef:            "foo",
@@ -78,6 +86,7 @@ func Test_componentConverter_convertEvidence(t *testing.T) {
 
 		convert(&comp)
 
+		require.Len(t, *comp.Evidence.Identity, 1)
 		require.Len(t, *comp.Evidence.Occurrences, 1)
 		occ := (*comp.Evidence.Occurrences)[0]
 		assert.Nil(t, occ.Line)

--- a/cyclonedx.go
+++ b/cyclonedx.go
@@ -623,7 +623,7 @@ type Event struct {
 }
 
 type Evidence struct {
-	Identity    *[]EvidenceIdentity   `json:",omitempty" xml:"-"`
+	Identity    *[]EvidenceIdentity   `json:"identity,omitempty" xml:"-"`
 	Occurrences *[]EvidenceOccurrence `json:"occurrences,omitempty" xml:"-"`
 	Callstack   *Callstack            `json:"callstack,omitempty" xml:"-"`
 	Licenses    *Licenses             `json:"licenses,omitempty" xml:"-"`

--- a/cyclonedx.go
+++ b/cyclonedx.go
@@ -623,11 +623,11 @@ type Event struct {
 }
 
 type Evidence struct {
-	Identity    *EvidenceIdentity     `json:"identity,omitempty" xml:"identity,omitempty"`
-	Occurrences *[]EvidenceOccurrence `json:"occurrences,omitempty" xml:"occurrences>occurrence,omitempty"`
-	Callstack   *Callstack            `json:"callstack,omitempty" xml:"callstack,omitempty"`
-	Licenses    *Licenses             `json:"licenses,omitempty" xml:"licenses,omitempty"`
-	Copyright   *[]Copyright          `json:"copyright,omitempty" xml:"copyright>text,omitempty"`
+	Identity    *[]EvidenceIdentity   `json:",omitempty" xml:"-"`
+	Occurrences *[]EvidenceOccurrence `json:"occurrences,omitempty" xml:"-"`
+	Callstack   *Callstack            `json:"callstack,omitempty" xml:"-"`
+	Licenses    *Licenses             `json:"licenses,omitempty" xml:"-"`
+	Copyright   *[]Copyright          `json:"copyright,omitempty" xml:"-"`
 }
 
 type EvidenceIdentity struct {

--- a/cyclonedx_json_test.go
+++ b/cyclonedx_json_test.go
@@ -220,7 +220,7 @@ func TestEvidence_MarshalJSON(t *testing.T) {
 		}
 		jsonBytes, err := json.Marshal(evidence)
 		require.NoError(t, err)
-		require.Equal(t, `{"Identity":[{"field":"purl","confidence":1,"methods":[{"technique":"filename","confidence":0.1,"value":"findbugs-project-3.0.0.jar"},{"technique":"ast-fingerprint","confidence":0.9,"value":"61e4bc08251761c3a73b606b9110a65899cb7d44f3b14c81ebc1e67c98e1d9ab"}],"tools":["bom-ref-of-tool-that-performed-analysis"]}]}`, string(jsonBytes))
+		require.Equal(t, `{"identity":[{"field":"purl","confidence":1,"methods":[{"technique":"filename","confidence":0.1,"value":"findbugs-project-3.0.0.jar"},{"technique":"ast-fingerprint","confidence":0.9,"value":"61e4bc08251761c3a73b606b9110a65899cb7d44f3b14c81ebc1e67c98e1d9ab"}],"tools":["bom-ref-of-tool-that-performed-analysis"]}]}`, string(jsonBytes))
 	})
 }
 

--- a/cyclonedx_json_test.go
+++ b/cyclonedx_json_test.go
@@ -19,8 +19,9 @@ package cyclonedx
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestEnvironmentVariableChoice_MarshalJSON(t *testing.T) {
@@ -164,5 +165,168 @@ func TestMLDatasetChoice_UnmarshalJSON(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "foo", choice.Ref)
 		require.Nil(t, choice.ComponentData)
+	})
+}
+
+func TestEvidence_MarshalJSON(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		evidence := Evidence{}
+		jsonBytes, err := json.Marshal(evidence)
+		require.NoError(t, err)
+		require.Equal(t, "{}", string(jsonBytes))
+	})
+
+	t.Run("WithOccurrences", func(t *testing.T) {
+		evidence := Evidence{
+			Occurrences: &[]EvidenceOccurrence{
+				{
+					BOMRef:   "d6bf237e-4e11-4713-9f62-56d18d5e2079",
+					Location: "/path/to/component",
+				},
+				{
+					BOMRef:   "b574d5d1-e3cf-4dcd-9ba5-f3507eb1b175",
+					Location: "/another/path/to/component",
+				},
+			},
+		}
+		jsonBytes, err := json.Marshal(evidence)
+		require.NoError(t, err)
+		require.Equal(t, `{"occurrences":[{"bom-ref":"d6bf237e-4e11-4713-9f62-56d18d5e2079","location":"/path/to/component"},{"bom-ref":"b574d5d1-e3cf-4dcd-9ba5-f3507eb1b175","location":"/another/path/to/component"}]}`, string(jsonBytes))
+	})
+
+	t.Run("WithIdentify", func(t *testing.T) {
+		evidence := Evidence{
+			Identity: &[]EvidenceIdentity{
+				{
+					Field:      EvidenceIdentityFieldTypePURL,
+					Confidence: toPointer(t, float32(1)),
+					Methods: &[]EvidenceIdentityMethod{
+						{
+							Technique:  "filename",
+							Confidence: toPointer(t, float32(0.1)),
+							Value:      "findbugs-project-3.0.0.jar",
+						},
+						{
+							Technique:  "ast-fingerprint",
+							Confidence: toPointer(t, float32(0.9)),
+							Value:      "61e4bc08251761c3a73b606b9110a65899cb7d44f3b14c81ebc1e67c98e1d9ab",
+						},
+					},
+					Tools: &[]BOMReference{
+						"bom-ref-of-tool-that-performed-analysis",
+					},
+				},
+			},
+		}
+		jsonBytes, err := json.Marshal(evidence)
+		require.NoError(t, err)
+		require.Equal(t, `{"Identity":[{"field":"purl","confidence":1,"methods":[{"technique":"filename","confidence":0.1,"value":"findbugs-project-3.0.0.jar"},{"technique":"ast-fingerprint","confidence":0.9,"value":"61e4bc08251761c3a73b606b9110a65899cb7d44f3b14c81ebc1e67c98e1d9ab"}],"tools":["bom-ref-of-tool-that-performed-analysis"]}]}`, string(jsonBytes))
+	})
+}
+
+func TestEvidence_UnmarshalJSON(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		var evidence Evidence
+		err := json.Unmarshal([]byte(`{}`), &evidence)
+		require.NoError(t, err)
+		require.Equal(t, Evidence{}, evidence)
+	})
+
+	t.Run("WithOccurrences", func(t *testing.T) {
+		var evidence Evidence
+		err := json.Unmarshal([]byte(`{
+"occurrences": [
+  {
+	"bom-ref": "d6bf237e-4e11-4713-9f62-56d18d5e2079",
+	"location": "/path/to/component"
+  },
+  {
+	"bom-ref": "b574d5d1-e3cf-4dcd-9ba5-f3507eb1b175",
+	"location": "/another/path/to/component"
+  }
+]}`), &evidence)
+		require.NoError(t, err)
+		require.Equal(t, &[]EvidenceOccurrence{
+			{
+				BOMRef:   "d6bf237e-4e11-4713-9f62-56d18d5e2079",
+				Location: "/path/to/component",
+			},
+			{
+				BOMRef:   "b574d5d1-e3cf-4dcd-9ba5-f3507eb1b175",
+				Location: "/another/path/to/component",
+			},
+		}, evidence.Occurrences)
+	})
+
+	t.Run("WithIdentityAsStruct", func(t *testing.T) {
+		var evidence Evidence
+		err := json.Unmarshal([]byte(`{
+"identity": {
+  "field": "purl",
+  "confidence": 1,
+  "methods": [
+	{
+	  "technique": "filename",
+	  "confidence": 0.1,
+	  "value": "findbugs-project-3.0.0.jar"
+	},
+	{
+	  "technique": "ast-fingerprint",
+	  "confidence": 0.9,
+	  "value": "61e4bc08251761c3a73b606b9110a65899cb7d44f3b14c81ebc1e67c98e1d9ab"
+	}
+  ],
+  "tools": [
+	"bom-ref-of-tool-that-performed-analysis"
+  ]
+}}`), &evidence)
+		require.NoError(t, err)
+		require.Equal(t, &[]EvidenceIdentity{
+			{
+				Field:      EvidenceIdentityFieldTypePURL,
+				Confidence: toPointer(t, float32(1)),
+				Methods: &[]EvidenceIdentityMethod{
+					{
+						Technique:  "filename",
+						Confidence: toPointer(t, float32(0.1)),
+						Value:      "findbugs-project-3.0.0.jar",
+					},
+					{
+						Technique:  "ast-fingerprint",
+						Confidence: toPointer(t, float32(0.9)),
+						Value:      "61e4bc08251761c3a73b606b9110a65899cb7d44f3b14c81ebc1e67c98e1d9ab",
+					},
+				},
+				Tools: &[]BOMReference{
+					"bom-ref-of-tool-that-performed-analysis",
+				},
+			},
+		}, evidence.Identity)
+	})
+
+	t.Run("WithIdentityAsArray", func(t *testing.T) {
+		var evidence Evidence
+		err := json.Unmarshal([]byte(`{
+"identity": [
+	{
+		"field": "purl",
+		"confidence": 1
+	},
+	{
+		"field": "name",
+		"confidence": 0.1
+	}
+]}`), &evidence)
+		require.NoError(t, err)
+		require.Equal(t, &[]EvidenceIdentity{
+			{
+				Field:      EvidenceIdentityFieldTypePURL,
+				Confidence: toPointer(t, float32(1)),
+			},
+			{
+				Field:      EvidenceIdentityFieldTypeName,
+				Confidence: toPointer(t, float32(0.1)),
+			},
+		}, evidence.Identity)
 	})
 }

--- a/cyclonedx_xml.go
+++ b/cyclonedx_xml.go
@@ -406,6 +406,149 @@ func (tc *ToolsChoice) UnmarshalXML(d *xml.Decoder, _ xml.StartElement) error {
 	return nil
 }
 
+// EvidenceMarshalXML is temporarily used for marshalling
+// Evidence instances from XML.
+type EvidenceMarshalXML struct {
+	Identity    *[]EvidenceIdentity   `json:"-" xml:"identity,omitempty"`
+	Occurrences *[]EvidenceOccurrence `json:"-" xml:"occurrences>occurrence,omitempty"`
+	Callstack   *Callstack            `json:"-" xml:"callstack,omitempty"`
+	Licenses    *Licenses             `json:"-" xml:"licenses,omitempty"`
+	Copyright   *[]Copyright          `json:"-" xml:"copyright>text,omitempty"`
+}
+
+// EvidenceUnmarshalXML is temporarily used for unmarshalling
+// Evidence instances from XML.
+type EvidenceUnmarshalXML struct {
+	Occurrences *[]EvidenceOccurrence `json:"-" xml:"occurrence,omitempty"`
+	Copyright   *[]Copyright          `json:"-" xml:"text,omitempty"`
+}
+
+func (ev Evidence) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	evidenceXML := EvidenceMarshalXML{}
+	empty := true
+	if ev.Identity != nil {
+		evidenceXML.Identity = ev.Identity
+		empty = false
+	}
+	if ev.Occurrences != nil {
+		evidenceXML.Occurrences = ev.Occurrences
+		empty = false
+	}
+	if ev.Callstack != nil {
+		evidenceXML.Callstack = ev.Callstack
+		empty = false
+	}
+	if ev.Licenses != nil {
+		evidenceXML.Licenses = ev.Licenses
+		empty = false
+	}
+	if ev.Copyright != nil {
+		evidenceXML.Copyright = ev.Copyright
+		empty = false
+	}
+
+	if !empty {
+		return e.EncodeElement(evidenceXML, start)
+	}
+
+	return nil
+}
+
+func (ev *Evidence) UnmarshalXML(d *xml.Decoder, _ xml.StartElement) error {
+	var evidence Evidence
+	var identifies []EvidenceIdentity
+
+	for {
+		token, err := d.Token()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return err
+		}
+
+		switch tokenType := token.(type) {
+		case xml.StartElement:
+			if tokenType.Name.Local == "identity" {
+				var identity EvidenceIdentity
+				if err = d.DecodeElement(&identity, &tokenType); err != nil {
+					return err
+				}
+				identifies = append(identifies, identity)
+			} else if tokenType.Name.Local == "occurrences" {
+				var evidenceXml EvidenceUnmarshalXML
+				if err = d.DecodeElement(&evidenceXml, &tokenType); err != nil {
+					return err
+				}
+				if evidenceXml.Occurrences != nil {
+					evidence.Occurrences = evidenceXml.Occurrences
+				}
+			} else if tokenType.Name.Local == "callstack" {
+				var cs Callstack
+				if err = d.DecodeElement(&cs, &tokenType); err != nil {
+					return err
+				}
+				if cs.Frames != nil {
+					evidence.Callstack = &cs
+				}
+			} else if tokenType.Name.Local == "licenses" {
+				var licenses Licenses
+				if err = d.DecodeElement(&licenses, &tokenType); err != nil {
+					return err
+				}
+				if len(licenses) > 0 {
+					evidence.Licenses = &licenses
+				}
+			} else if tokenType.Name.Local == "copyright" {
+				var evidenceXml EvidenceUnmarshalXML
+				if err = d.DecodeElement(&evidenceXml, &tokenType); err != nil {
+					return err
+				}
+				if evidenceXml.Copyright != nil {
+					evidence.Copyright = evidenceXml.Copyright
+				}
+			} else {
+				return fmt.Errorf("unknown element: %s", tokenType.Name.Local)
+			}
+		}
+	}
+
+	if len(identifies) > 0 {
+		evidence.Identity = &identifies
+	}
+
+	*ev = evidence
+	return nil
+}
+
+//func (eic *EvidenceIdentityChoice) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+//	// Try to decode as single struct
+//	var evidenceIdentity []EvidenceIdentity
+//	err := d.DecodeElement(&evidenceIdentity, &start)
+//	if err != nil {
+//		// Try to decode as array
+//		var evidenceIdentities []EvidenceIdentity
+//		err = d.DecodeElement(&evidenceIdentities, &start)
+//		if err != nil {
+//			return fmt.Errorf("unable to decode EvidenceIdentity as array or single struct (depricated): %v", err)
+//		}
+//		*eic = EvidenceIdentityChoice{
+//			EvidenceIdentities: evidenceIdentities,
+//		}
+//		return nil
+//	}
+//
+//	//if evidenceIdentity.Field != "" {
+//	//	*eic = EvidenceIdentityChoice{
+//	//		EvidenceIdentities: []EvidenceIdentity{
+//	//			evidenceIdentity,
+//	//		},
+//	//	}
+//	//}
+//
+//	return nil
+//}
+
 var xmlNamespaces = map[SpecVersion]string{
 	SpecVersion1_0: "http://cyclonedx.org/schema/bom/1.0",
 	SpecVersion1_1: "http://cyclonedx.org/schema/bom/1.1",

--- a/cyclonedx_xml.go
+++ b/cyclonedx_xml.go
@@ -521,34 +521,6 @@ func (ev *Evidence) UnmarshalXML(d *xml.Decoder, _ xml.StartElement) error {
 	return nil
 }
 
-//func (eic *EvidenceIdentityChoice) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
-//	// Try to decode as single struct
-//	var evidenceIdentity []EvidenceIdentity
-//	err := d.DecodeElement(&evidenceIdentity, &start)
-//	if err != nil {
-//		// Try to decode as array
-//		var evidenceIdentities []EvidenceIdentity
-//		err = d.DecodeElement(&evidenceIdentities, &start)
-//		if err != nil {
-//			return fmt.Errorf("unable to decode EvidenceIdentity as array or single struct (depricated): %v", err)
-//		}
-//		*eic = EvidenceIdentityChoice{
-//			EvidenceIdentities: evidenceIdentities,
-//		}
-//		return nil
-//	}
-//
-//	//if evidenceIdentity.Field != "" {
-//	//	*eic = EvidenceIdentityChoice{
-//	//		EvidenceIdentities: []EvidenceIdentity{
-//	//			evidenceIdentity,
-//	//		},
-//	//	}
-//	//}
-//
-//	return nil
-//}
-
 var xmlNamespaces = map[SpecVersion]string{
 	SpecVersion1_0: "http://cyclonedx.org/schema/bom/1.0",
 	SpecVersion1_1: "http://cyclonedx.org/schema/bom/1.1",

--- a/testdata/snapshots/cyclonedx-go-TestRoundTripJSON-func1-valid-evidence.json
+++ b/testdata/snapshots/cyclonedx-go-TestRoundTripJSON-func1-valid-evidence.json
@@ -19,30 +19,32 @@
       ],
       "purl": "pkg:maven/com.google.code.findbugs/findbugs-project@3.0.0",
       "evidence": {
-        "identity": {
-          "field": "purl",
-          "confidence": 1,
-          "methods": [
-            {
-              "technique": "filename",
-              "confidence": 0.1,
-              "value": "findbugs-project-3.0.0.jar"
-            },
-            {
-              "technique": "ast-fingerprint",
-              "confidence": 0.9,
-              "value": "61e4bc08251761c3a73b606b9110a65899cb7d44f3b14c81ebc1e67c98e1d9ab"
-            },
-            {
-              "technique": "hash-comparison",
-              "confidence": 0.7,
-              "value": "7c547a9d67cc7bc315c93b6e2ff8e4b6b41ae5be454ac249655ecb5ca2a85abf"
-            }
-          ],
-          "tools": [
-            "bom-ref-of-tool-that-performed-analysis"
-          ]
-        },
+        "identity": [
+          {
+            "field": "purl",
+            "confidence": 1,
+            "methods": [
+              {
+                "technique": "filename",
+                "confidence": 0.1,
+                "value": "findbugs-project-3.0.0.jar"
+              },
+              {
+                "technique": "ast-fingerprint",
+                "confidence": 0.9,
+                "value": "61e4bc08251761c3a73b606b9110a65899cb7d44f3b14c81ebc1e67c98e1d9ab"
+              },
+              {
+                "technique": "hash-comparison",
+                "confidence": 0.7,
+                "value": "7c547a9d67cc7bc315c93b6e2ff8e4b6b41ae5be454ac249655ecb5ca2a85abf"
+              }
+            ],
+            "tools": [
+              "bom-ref-of-tool-that-performed-analysis"
+            ]
+          }
+        ],
         "occurrences": [
           {
             "bom-ref": "d6bf237e-4e11-4713-9f62-56d18d5e2079",

--- a/testdata/valid-evidence.json
+++ b/testdata/valid-evidence.json
@@ -19,30 +19,32 @@
       ],
       "purl": "pkg:maven/com.google.code.findbugs/findbugs-project@3.0.0",
       "evidence": {
-        "identity": {
-          "field": "purl",
-          "confidence": 1,
-          "methods": [
-            {
-              "technique": "filename",
-              "confidence": 0.1,
-              "value": "findbugs-project-3.0.0.jar"
-            },
-            {
-              "technique": "ast-fingerprint",
-              "confidence": 0.9,
-              "value": "61e4bc08251761c3a73b606b9110a65899cb7d44f3b14c81ebc1e67c98e1d9ab"
-            },
-            {
-              "technique": "hash-comparison",
-              "confidence": 0.7,
-              "value": "7c547a9d67cc7bc315c93b6e2ff8e4b6b41ae5be454ac249655ecb5ca2a85abf"
-            }
-          ],
-          "tools": [
-            "bom-ref-of-tool-that-performed-analysis"
-          ]
-        },
+        "identity": [
+          {
+            "field": "purl",
+            "confidence": 1,
+            "methods": [
+              {
+                "technique": "filename",
+                "confidence": 0.1,
+                "value": "findbugs-project-3.0.0.jar"
+              },
+              {
+                "technique": "ast-fingerprint",
+                "confidence": 0.9,
+                "value": "61e4bc08251761c3a73b606b9110a65899cb7d44f3b14c81ebc1e67c98e1d9ab"
+              },
+              {
+                "technique": "hash-comparison",
+                "confidence": 0.7,
+                "value": "7c547a9d67cc7bc315c93b6e2ff8e4b6b41ae5be454ac249655ecb5ca2a85abf"
+              }
+            ],
+            "tools": [
+              "bom-ref-of-tool-that-performed-analysis"
+            ]
+          }
+        ],
         "occurrences": [
           {
             "bom-ref": "d6bf237e-4e11-4713-9f62-56d18d5e2079",


### PR DESCRIPTION
## Description
in CycloneDX 1.6 type of `Component.Evidence.Identity` has been changed to `[]Identity`.
`Identity` as `struct` was marked as `deprecated`.
https://cyclonedx.org/docs/1.6/json/#tab-pane_metadata_component_evidence_identity_oneOf_i0

## Related issues
- Close #192