### PR TITLE
Add Component Type Unknown to handle some accidental cases

### DIFF
--- a/cyclonedx.go
+++ b/cyclonedx.go
@@ -210,6 +210,7 @@ const (
 	ComponentTypeMachineLearningModel ComponentType = "machine-learning-model"
 	ComponentTypeOS                   ComponentType = "operating-system"
 	ComponentTypePlatform             ComponentType = "platform"
+	ComponentTypeUnknown		  ComponentType = "unknown"
 )
 
 type Commit struct {

--- a/cyclonedx.go
+++ b/cyclonedx.go
@@ -210,7 +210,7 @@ const (
 	ComponentTypeMachineLearningModel ComponentType = "machine-learning-model"
 	ComponentTypeOS                   ComponentType = "operating-system"
 	ComponentTypePlatform             ComponentType = "platform"
-	ComponentTypeUnknown		  ComponentType = "unknown"
+	ComponentTypeUnknown              ComponentType = "unknown"
 )
 
 type Commit struct {


### PR DESCRIPTION
## Why is it essential ?
some SBOM Generator like Syft only support identifying limited number of Component Types like File,Image ,&c currently. But there are many types like framework beyond the capacity of Syft. So for accuracy , an unknown type is required. Don't worry it will compromise the standard of Cyclone DX , since we have to tackle some weird edge cases when it comes to the implementation.

Fixes #229 