### PR TITLE
Add comprehensive support for CycloneDX 1.7 specification

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -558,9 +558,9 @@ func serviceConverter(specVersion SpecVersion) func(*Service) {
 			convertDataClassifications(s.Data, specVersion)
 		}
 
-    if specVersion < SpecVersion1_7 {
+		if specVersion < SpecVersion1_7 {
 			s.PatentAssertions = nil
-    }
+		}
 
 		convertOrganizationalEntity(s.Provider, specVersion)
 		convertExternalReferences(s.ExternalReferences, specVersion)

--- a/convert.go
+++ b/convert.go
@@ -58,6 +58,9 @@ func (b *BOM) convert(specVersion SpecVersion) {
 	}
 	if specVersion < SpecVersion1_7 {
 		b.Citations = nil
+		if b.Definitions != nil {
+			b.Definitions.Patents = nil
+		}
 	}
 
 	if b.Dependencies != nil && specVersion < SpecVersion1_6 {
@@ -223,6 +226,11 @@ func convertEvidence(c *Component, specVersion SpecVersion) {
 			ids = ids[:1]
 			c.Evidence.Identity = &EvidenceIdentityChoice{Identities: &ids}
 		}
+		if c.Evidence.Identity != nil && c.Evidence.Identity.Identities != nil {
+			for i := range *c.Evidence.Identity.Identities {
+				(*c.Evidence.Identity.Identities)[i].ConcludedValue = ""
+			}
+		}
 		if c.Evidence.Occurrences != nil {
 			for i := range *c.Evidence.Occurrences {
 				occ := &(*c.Evidence.Occurrences)[i]
@@ -381,6 +389,15 @@ func convertLicenses(licenses *Licenses, specVersion SpecVersion) {
 			}
 		}
 	}
+
+	if specVersion < SpecVersion1_7 {
+		for i := range *licenses {
+			choice := &(*licenses)[i]
+			choice.ExpressionDetails = nil
+			choice.Licensing = nil
+			choice.Properties = nil
+		}
+	}
 }
 
 func convertOrganizationalEntity(org *OrganizationalEntity, specVersion SpecVersion) {
@@ -435,6 +452,13 @@ func convertCryptoProperties(cp *CryptoProperties, specVersion SpecVersion) {
 			cp.AlgorithmProperties.AlgorithmFamily = ""
 			cp.AlgorithmProperties.EllipticCurve = ""
 		}
+		if !specVersion.supportsCryptoPrimitive(cp.AlgorithmProperties.Primitive) {
+			cp.AlgorithmProperties.Primitive = ""
+		}
+	}
+
+	if cp.ProtocolProperties != nil && !specVersion.supportsCryptoProtocolType(cp.ProtocolProperties.Type) {
+		cp.ProtocolProperties.Type = ""
 	}
 
 	if cp.CertificateProperties != nil {
@@ -759,9 +783,29 @@ func (sv SpecVersion) supportsExternalReferenceType(ert ExternalReferenceType) b
 		ERTypeThreatModel,
 		ERTypeVulnerabilityAssertion:
 		return sv >= SpecVersion1_5
+	case ERTypePatent, ERTypePatentFamily, ERTypePatentAssertion, ERTypeCitation:
+		return sv >= SpecVersion1_7
 	}
 
 	return sv >= SpecVersion1_1
+}
+
+func (sv SpecVersion) supportsCryptoPrimitive(primitive CryptoPrimitive) bool {
+	switch primitive {
+	case CryptoPrimitiveKeyWrap:
+		return sv >= SpecVersion1_7
+	}
+	return sv >= SpecVersion1_6
+}
+
+func (sv SpecVersion) supportsCryptoProtocolType(pt CryptoProtocolType) bool {
+	switch pt {
+	case CryptoProtocolTypeDTLS, CryptoProtocolTypeQUIC,
+		CryptoProtocolTypeEAPAKA, CryptoProtocolTypeEAPAKAPrime,
+		CryptoProtocolTypePRINS, CryptoProtocolType5GAKA:
+		return sv >= SpecVersion1_7
+	}
+	return sv >= SpecVersion1_6
 }
 
 func (sv SpecVersion) supportsHashAlgorithm(algo HashAlgorithm) bool {

--- a/convert.go
+++ b/convert.go
@@ -218,10 +218,10 @@ func convertEvidence(c *Component, specVersion SpecVersion) {
 	if specVersion < SpecVersion1_6 {
 		// Spec version 1.5 uses only one Identity.
 		// cf. https://cyclonedx.org/docs/1.5/json/#components_items_evidence_identity
-		if c.Evidence.Identity != nil {
-			ids := *c.Evidence.Identity
+		if c.Evidence.Identity != nil && c.Evidence.Identity.Identities != nil {
+			ids := *c.Evidence.Identity.Identities
 			ids = ids[:1]
-			c.Evidence.Identity = &ids
+			c.Evidence.Identity = &EvidenceIdentityChoice{Identities: &ids}
 		}
 		if c.Evidence.Occurrences != nil {
 			for i := range *c.Evidence.Occurrences {

--- a/convert_test.go
+++ b/convert_test.go
@@ -42,7 +42,7 @@ func Test_componentConverter_convertEvidence(t *testing.T) {
 
 		comp := Component{
 			Evidence: &Evidence{
-				Identity:    &[]EvidenceIdentity{},
+				Identity:    &EvidenceIdentityChoice{Identities: &[]EvidenceIdentity{}},
 				Occurrences: &[]EvidenceOccurrence{},
 				Callstack:   &Callstack{},
 				Copyright:   &[]Copyright{{Text: "foo"}},
@@ -63,14 +63,14 @@ func Test_componentConverter_convertEvidence(t *testing.T) {
 
 		comp := Component{
 			Evidence: &Evidence{
-				Identity: &[]EvidenceIdentity{
+				Identity: &EvidenceIdentityChoice{Identities: &[]EvidenceIdentity{
 					{
 						Field: EvidenceIdentityFieldTypePURL,
 					},
 					{
 						Field: EvidenceIdentityFieldTypeName,
 					},
-				},
+				}},
 				Occurrences: &[]EvidenceOccurrence{
 					{
 						BOMRef:            "foo",
@@ -86,7 +86,7 @@ func Test_componentConverter_convertEvidence(t *testing.T) {
 
 		convert(&comp)
 
-		require.Len(t, *comp.Evidence.Identity, 1)
+		require.Len(t, *comp.Evidence.Identity.Identities, 1)
 		require.Len(t, *comp.Evidence.Occurrences, 1)
 		occ := (*comp.Evidence.Occurrences)[0]
 		assert.Nil(t, occ.Line)

--- a/cyclonedx.go
+++ b/cyclonedx.go
@@ -126,15 +126,16 @@ type BOM struct {
 	Formulation        *[]Formula           `json:"formulation,omitempty" xml:"formulation>formula,omitempty"`
 	Declarations       *Declarations        `json:"declarations,omitempty" xml:"declarations,omitempty"`
 	Definitions        *Definitions         `json:"definitions,omitempty" xml:"definitions,omitempty"`
+	Citations          *[]Citation          `json:"citations,omitempty" xml:"citations>citation,omitempty"`
 	Signature          *JSFSignature        `json:"signature,omitempty" xml:"-"`
 }
 
 func NewBOM() *BOM {
 	return &BOM{
-		JSONSchema:  jsonSchemas[SpecVersion1_6],
-		XMLNS:       xmlNamespaces[SpecVersion1_6],
+		JSONSchema:  jsonSchemas[SpecVersion1_7],
+		XMLNS:       xmlNamespaces[SpecVersion1_7],
 		BOMFormat:   BOMFormat,
-		SpecVersion: SpecVersion1_6,
+		SpecVersion: SpecVersion1_7,
 		Version:     1,
 	}
 }
@@ -168,14 +169,25 @@ type CallstackFrame struct {
 }
 
 type CertificateProperties struct {
-	SubjectName           string       `json:"subjectName,omitempty" xml:"subjectName,omitempty"`
-	IssuerName            string       `json:"issuerName,omitempty" xml:"issuerName,omitempty"`
-	NotValidBefore        string       `json:"notValidBefore,omitempty" xml:"notValidBefore,omitempty"`
-	NotValidAfter         string       `json:"notValidAfter,omitempty" xml:"notValidAfter,omitempty"`
-	SignatureAlgorithmRef BOMReference `json:"signatureAlgorithmRef,omitempty" xml:"signatureAlgorithmRef,omitempty"`
-	SubjectPublicKeyRef   BOMReference `json:"subjectPublicKeyRef,omitempty" xml:"subjectPublicKeyRef,omitempty"`
-	CertificateFormat     string       `json:"certificateFormat,omitempty" xml:"certificateFormat,omitempty"`
-	CertificateExtension  string       `json:"certificateExtension,omitempty" xml:"certificateExtension,omitempty"`
+	SerialNumber              string                           `json:"serialNumber,omitempty" xml:"serialNumber,omitempty"`
+	SubjectName               string                           `json:"subjectName,omitempty" xml:"subjectName,omitempty"`
+	IssuerName                string                           `json:"issuerName,omitempty" xml:"issuerName,omitempty"`
+	NotValidBefore            string                           `json:"notValidBefore,omitempty" xml:"notValidBefore,omitempty"`
+	NotValidAfter             string                           `json:"notValidAfter,omitempty" xml:"notValidAfter,omitempty"`
+	SignatureAlgorithmRef     BOMReference                     `json:"signatureAlgorithmRef,omitempty" xml:"signatureAlgorithmRef,omitempty"` // Deprecated in 1.7: use RelatedCryptographicAssets
+	SubjectPublicKeyRef       BOMReference                     `json:"subjectPublicKeyRef,omitempty" xml:"subjectPublicKeyRef,omitempty"`     // Deprecated in 1.7: use RelatedCryptographicAssets
+	CertificateFormat         string                           `json:"certificateFormat,omitempty" xml:"certificateFormat,omitempty"`
+	CertificateExtension      string                           `json:"certificateExtension,omitempty" xml:"certificateExtension,omitempty"`           // Deprecated in 1.7: use CertificateFileExtension
+	CertificateFileExtension  string                           `json:"certificateFileExtension,omitempty" xml:"certificateFileExtension,omitempty"`   // New in 1.7
+	Fingerprint               *Hash                            `json:"fingerprint,omitempty" xml:"fingerprint,omitempty"`                             // New in 1.7
+	CertificateState          *[]CertificateState              `json:"certificateState,omitempty" xml:"certificateState>state,omitempty"`             // New in 1.7
+	CertificateExtensions     *[]CertificateExtension          `json:"certificateExtensions,omitempty" xml:"certificateExtensions>extension,omitempty"` // New in 1.7
+	RelatedCryptographicAssets *[]RelatedCryptographicAsset    `json:"relatedCryptographicAssets,omitempty" xml:"relatedCryptographicAssets>relatedCryptographicAsset,omitempty"` // New in 1.7
+	CreationDate              string                           `json:"creationDate,omitempty" xml:"creationDate,omitempty"`               // New in 1.7
+	ActivationDate            string                           `json:"activationDate,omitempty" xml:"activationDate,omitempty"`           // New in 1.7
+	DeactivationDate          string                           `json:"deactivationDate,omitempty" xml:"deactivationDate,omitempty"`       // New in 1.7
+	RevocationDate            string                           `json:"revocationDate,omitempty" xml:"revocationDate,omitempty"`           // New in 1.7
+	DestructionDate           string                           `json:"destructionDate,omitempty" xml:"destructionDate,omitempty"`         // New in 1.7
 }
 
 type Claim struct {
@@ -191,9 +203,11 @@ type Claim struct {
 }
 
 type CipherSuite struct {
-	Name        string          `json:"name,omitempty" xml:"name,omitempty"`
-	Algorithms  *[]BOMReference `json:"algorithms,omitempty" xml:"algorithms,omitempty"`
-	Identifiers *[]string       `json:"identifiers,omitempty" xml:"identifiers,omitempty"`
+	Name                 string          `json:"name,omitempty" xml:"name,omitempty"`
+	Algorithms           *[]BOMReference `json:"algorithms,omitempty" xml:"algorithms,omitempty"`
+	Identifiers          *[]string       `json:"identifiers,omitempty" xml:"identifiers,omitempty"`
+	TLSGroups            *[]string       `json:"tlsGroups,omitempty" xml:"tlsGroups>group,omitempty"`
+	TLSSignatureSchemes  *[]string       `json:"tlsSignatureSchemes,omitempty" xml:"tlsSignatureSchemes>scheme,omitempty"`
 }
 
 type ComponentType string
@@ -255,6 +269,9 @@ type Component struct {
 	Data               *[]ComponentData         `json:"data,omitempty" xml:"data,omitempty"`
 	CryptoProperties   *CryptoProperties        `json:"cryptoProperties,omitempty" xml:"cryptoProperties,omitempty"`
 	Tags               *[]string                `json:"tags,omitempty" xml:"tags>tag,omitempty"`
+	IsExternal         *bool                    `json:"isExternal,omitempty" xml:"isExternal,omitempty"`
+	PatentAssertions   *[]PatentAssertion       `json:"patentAssertions,omitempty" xml:"patentAssertions>patentAssertion,omitempty"`
+	VersionRange       string                   `json:"versionRange,omitempty" xml:"versionRange,omitempty"`
 	Signature          *JSFSignature            `json:"signature,omitempty" xml:"-"`
 }
 
@@ -351,7 +368,9 @@ const (
 type CryptoAlgorithmProperties struct {
 	Primitive                CryptoPrimitive             `json:"primitive,omitempty" xml:"primitive,omitempty"`
 	ParameterSetIdentifier   string                      `json:"parameterSetIdentifier,omitempty" xml:"parameterSetIdentifier,omitempty"`
-	Curve                    string                      `json:"curve,omitempty" xml:"curve,omitempty"`
+	AlgorithmFamily          string                      `json:"algorithmFamily,omitempty" xml:"algorithmFamily,omitempty"`
+	Curve                    string                      `json:"curve,omitempty" xml:"curve,omitempty"` // Deprecated in 1.7: use EllipticCurve instead
+	EllipticCurve            string                      `json:"ellipticCurve,omitempty" xml:"ellipticCurve,omitempty"`
 	ExecutionEnvironment     CryptoExecutionEnvironment  `json:"executionEnvironment,omitempty" xml:"executionEnvironment,omitempty"`
 	ImplementationPlatform   ImplementationPlatform      `json:"implementationPlatform,omitempty" xml:"implementationPlatform,omitempty"`
 	CertificationLevel       *[]CryptoCertificationLevel `json:"certificationLevel,omitempty" xml:"certificationLevel,omitempty"`
@@ -487,11 +506,12 @@ type CryptoProperties struct {
 }
 
 type CryptoProtocolProperties struct {
-	Type                CryptoProtocolType   `json:"type,omitempty" xml:"type,omitempty"`
-	Version             string               `json:"version,omitempty" xml:"version,omitempty"`
-	CipherSuites        *[]CipherSuite       `json:"cipherSuites,omitempty" xml:"cipherSuites,omitempty"`
-	IKEv2TransformTypes *IKEv2TransformTypes `json:"ikev2TransformTypes,omitempty" xml:"ikev2TransformTypes,omitempty"`
-	CryptoRefArray      *[]BOMReference      `json:"cryptoRefArray,omitempty" xml:"cryptoRefArray,omitempty"`
+	Type                       CryptoProtocolType            `json:"type,omitempty" xml:"type,omitempty"`
+	Version                    string                        `json:"version,omitempty" xml:"version,omitempty"`
+	CipherSuites               *[]CipherSuite                `json:"cipherSuites,omitempty" xml:"cipherSuites,omitempty"`
+	IKEv2TransformTypes        *IKEv2TransformTypes          `json:"ikev2TransformTypes,omitempty" xml:"ikev2TransformTypes,omitempty"`
+	CryptoRefArray             *[]BOMReference               `json:"cryptoRefArray,omitempty" xml:"cryptoRefArray,omitempty"`
+	RelatedCryptographicAssets *[]RelatedCryptographicAsset  `json:"relatedCryptographicAssets,omitempty" xml:"relatedCryptographicAssets>relatedCryptographicAsset,omitempty"` // New in 1.7
 }
 
 type CryptoProtocolType string
@@ -688,10 +708,11 @@ type EvidenceOccurrence struct {
 }
 
 type ExternalReference struct {
-	URL     string                `json:"url" xml:"url"`
-	Comment string                `json:"comment,omitempty" xml:"comment,omitempty"`
-	Hashes  *[]Hash               `json:"hashes,omitempty" xml:"hashes>hash,omitempty"`
-	Type    ExternalReferenceType `json:"type" xml:"type,attr"`
+	URL        string                `json:"url" xml:"url"`
+	Comment    string                `json:"comment,omitempty" xml:"comment,omitempty"`
+	Hashes     *[]Hash               `json:"hashes,omitempty" xml:"hashes>hash,omitempty"`
+	Type       ExternalReferenceType `json:"type" xml:"type,attr"`
+	Properties *[]Property           `json:"properties,omitempty" xml:"properties>property,omitempty"`
 }
 
 type ExternalReferenceType string
@@ -758,18 +779,20 @@ type Hash struct {
 type HashAlgorithm string
 
 const (
-	HashAlgoMD5         HashAlgorithm = "MD5"
-	HashAlgoSHA1        HashAlgorithm = "SHA-1"
-	HashAlgoSHA256      HashAlgorithm = "SHA-256"
-	HashAlgoSHA384      HashAlgorithm = "SHA-384"
-	HashAlgoSHA512      HashAlgorithm = "SHA-512"
-	HashAlgoSHA3_256    HashAlgorithm = "SHA3-256"
-	HashAlgoSHA3_384    HashAlgorithm = "SHA3-384"
-	HashAlgoSHA3_512    HashAlgorithm = "SHA3-512"
-	HashAlgoBlake2b_256 HashAlgorithm = "BLAKE2b-256"
-	HashAlgoBlake2b_384 HashAlgorithm = "BLAKE2b-384"
-	HashAlgoBlake2b_512 HashAlgorithm = "BLAKE2b-512"
-	HashAlgoBlake3      HashAlgorithm = "BLAKE3"
+	HashAlgoMD5           HashAlgorithm = "MD5"
+	HashAlgoSHA1          HashAlgorithm = "SHA-1"
+	HashAlgoSHA256        HashAlgorithm = "SHA-256"
+	HashAlgoSHA384        HashAlgorithm = "SHA-384"
+	HashAlgoSHA512        HashAlgorithm = "SHA-512"
+	HashAlgoSHA3_256      HashAlgorithm = "SHA3-256"
+	HashAlgoSHA3_384      HashAlgorithm = "SHA3-384"
+	HashAlgoSHA3_512      HashAlgorithm = "SHA3-512"
+	HashAlgoBlake2b_256   HashAlgorithm = "BLAKE2b-256"
+	HashAlgoBlake2b_384   HashAlgorithm = "BLAKE2b-384"
+	HashAlgoBlake2b_512   HashAlgorithm = "BLAKE2b-512"
+	HashAlgoBlake3        HashAlgorithm = "BLAKE3"
+	HashAlgoStreebog256   HashAlgorithm = "Streebog-256"
+	HashAlgoStreebog512   HashAlgorithm = "Streebog-512"
 )
 
 type IdentifiableAction struct {
@@ -976,10 +999,11 @@ type Metadata struct {
 	Authors      *[]OrganizationalContact `json:"authors,omitempty" xml:"authors>author,omitempty"`
 	Component    *Component               `json:"component,omitempty" xml:"component,omitempty"`
 	Manufacture  *OrganizationalEntity    `json:"manufacture,omitempty" xml:"manufacture,omitempty"` // Deprecated: Use Component Manufacturer instead.
-	Manufacturer *OrganizationalEntity    `json:"manufacturer,omitempty" xml:"manufacturer,omitempty"`
-	Supplier     *OrganizationalEntity    `json:"supplier,omitempty" xml:"supplier,omitempty"`
-	Licenses     *Licenses                `json:"licenses,omitempty" xml:"licenses,omitempty"`
-	Properties   *[]Property              `json:"properties,omitempty" xml:"properties>property,omitempty"`
+	Manufacturer             *OrganizationalEntity     `json:"manufacturer,omitempty" xml:"manufacturer,omitempty"`
+	Supplier                 *OrganizationalEntity     `json:"supplier,omitempty" xml:"supplier,omitempty"`
+	Licenses                 *Licenses                 `json:"licenses,omitempty" xml:"licenses,omitempty"`
+	Properties               *[]Property               `json:"properties,omitempty" xml:"properties>property,omitempty"`
+	DistributionConstraints  *DistributionConstraints  `json:"distributionConstraints,omitempty" xml:"distributionConstraints,omitempty"`
 }
 
 type MLDatasetChoice struct {
@@ -1209,18 +1233,20 @@ type Property struct {
 }
 
 type RelatedCryptoMaterialProperties struct {
-	Type           RelatedCryptoMaterialType `json:"type,omitempty" xml:"type,omitempty"`
-	ID             string                    `json:"id,omitempty" xml:"id,omitempty"`
-	State          CryptoKeyState            `json:"state,omitempty" xml:"state,omitempty"`
-	AlgorithmRef   BOMReference              `json:"algorithmRef,omitempty" xml:"algorithmRef,omitempty"`
-	CreationDate   string                    `json:"creationDate,omitempty" xml:"creationDate,omitempty"`
-	ActivationDate string                    `json:"activationDate,omitempty" xml:"activationDate,omitempty"`
-	UpdateDate     string                    `json:"updateDate,omitempty" xml:"updateDate,omitempty"`
-	ExpirationDate string                    `json:"expirationDate,omitempty" xml:"expirationDate,omitempty"`
-	Value          string                    `json:"value,omitempty" xml:"value,omitempty"`
-	Size           *int                      `json:"size,omitempty" xml:"size,omitempty"`
-	Format         string                    `json:"format,omitempty" xml:"format,omitempty"`
-	SecuredBy      *SecuredBy                `json:"securedBy,omitempty" xml:"securedBy,omitempty"`
+	Type                       RelatedCryptoMaterialType     `json:"type,omitempty" xml:"type,omitempty"`
+	ID                         string                        `json:"id,omitempty" xml:"id,omitempty"`
+	State                      CryptoKeyState                `json:"state,omitempty" xml:"state,omitempty"`
+	AlgorithmRef               BOMReference                  `json:"algorithmRef,omitempty" xml:"algorithmRef,omitempty"` // Deprecated in 1.7: use RelatedCryptographicAssets
+	CreationDate               string                        `json:"creationDate,omitempty" xml:"creationDate,omitempty"`
+	ActivationDate             string                        `json:"activationDate,omitempty" xml:"activationDate,omitempty"`
+	UpdateDate                 string                        `json:"updateDate,omitempty" xml:"updateDate,omitempty"`
+	ExpirationDate             string                        `json:"expirationDate,omitempty" xml:"expirationDate,omitempty"`
+	Value                      string                        `json:"value,omitempty" xml:"value,omitempty"`
+	Size                       *int                          `json:"size,omitempty" xml:"size,omitempty"`
+	Format                     string                        `json:"format,omitempty" xml:"format,omitempty"`
+	SecuredBy                  *SecuredBy                    `json:"securedBy,omitempty" xml:"securedBy,omitempty"`
+	Fingerprint                *Hash                         `json:"fingerprint,omitempty" xml:"fingerprint,omitempty"`                                                                                 // New in 1.7
+	RelatedCryptographicAssets *[]RelatedCryptographicAsset  `json:"relatedCryptographicAssets,omitempty" xml:"relatedCryptographicAssets>relatedCryptographicAsset,omitempty"` // New in 1.7
 }
 
 type RelatedCryptoMaterialType string
@@ -1304,6 +1330,7 @@ type Service struct {
 	ReleaseNotes         *ReleaseNotes         `json:"releaseNotes,omitempty" xml:"releaseNotes,omitempty"`
 	Tags                 *[]string             `json:"tags,omitempty" xml:"tags>tag,omitempty"`
 	TrustZone            string                `json:"trustZone,omitempty" xml:"trustZone,omitempty"`
+	PatentAssertions     *[]PatentAssertion    `json:"patentAssertions,omitempty" xml:"patentAssertions>patentAssertion,omitempty"`
 	Signature            *JSFSignature         `json:"signature,omitempty" xml:"-"`
 }
 
@@ -1336,6 +1363,7 @@ const (
 	SpecVersion1_4                        // 1.4
 	SpecVersion1_5                        // 1.5
 	SpecVersion1_6                        // 1.6
+	SpecVersion1_7                        // 1.7
 )
 
 type StandardDefinition struct {
@@ -1630,3 +1658,175 @@ type Workflow struct {
 	RuntimeTopology    *[]Dependency              `json:"runtimeTopology,omitempty" xml:"runtimeTopology>dependency,omitempty"`
 	Properties         *[]Property                `json:"properties,omitempty" xml:"properties>property,omitempty"`
 }
+
+// CycloneDX 1.7 types and definitions
+
+// Citation represents an attribution of data to a source
+type Citation struct {
+	BOMRef       string                   `json:"bom-ref,omitempty" xml:"bom-ref,attr,omitempty"`
+	Pointers     *[]string                `json:"pointers,omitempty" xml:"pointers>pointer,omitempty"`
+	Expressions  *[]string                `json:"expressions,omitempty" xml:"expressions>expression,omitempty"`
+	Timestamp    string                   `json:"timestamp,omitempty" xml:"timestamp,omitempty"`
+	AttributedTo *OrganizationalEntity    `json:"attributedTo,omitempty" xml:"attributedTo,omitempty"`
+	Process      string                   `json:"process,omitempty" xml:"process,omitempty"`
+	Note         string                   `json:"note,omitempty" xml:"note,omitempty"`
+	Signature    *JSFSignature            `json:"signature,omitempty" xml:"-"`
+}
+
+// Patent represents patent information
+type Patent struct {
+	BOMRef                string                      `json:"bom-ref,omitempty" xml:"bom-ref,attr,omitempty"`
+	PatentNumber          string                      `json:"patentNumber" xml:"patentNumber"`
+	ApplicationNumber     string                      `json:"applicationNumber,omitempty" xml:"applicationNumber,omitempty"`
+	Jurisdiction          string                      `json:"jurisdiction" xml:"jurisdiction"`
+	PriorityApplication   *PriorityApplication        `json:"priorityApplication,omitempty" xml:"priorityApplication,omitempty"`
+	PublicationNumber     string                      `json:"publicationNumber,omitempty" xml:"publicationNumber,omitempty"`
+	Title                 string                      `json:"title,omitempty" xml:"title,omitempty"`
+	Abstract              string                      `json:"abstract,omitempty" xml:"abstract,omitempty"`
+	FilingDate            string                      `json:"filingDate,omitempty" xml:"filingDate,omitempty"`
+	GrantDate             string                      `json:"grantDate,omitempty" xml:"grantDate,omitempty"`
+	PatentExpirationDate  string                      `json:"patentExpirationDate,omitempty" xml:"patentExpirationDate,omitempty"`
+	PatentLegalStatus     string                      `json:"patentLegalStatus" xml:"patentLegalStatus"`
+	PatentAssignee        *[]OrganizationalEntity     `json:"patentAssignee,omitempty" xml:"patentAssignee>assignee,omitempty"`
+	ExternalReferences    *[]ExternalReference        `json:"externalReferences,omitempty" xml:"externalReferences>reference,omitempty"`
+}
+
+// PatentFamily represents a patent family grouping
+type PatentFamily struct {
+	BOMRef              string                `json:"bom-ref,omitempty" xml:"bom-ref,attr,omitempty"`
+	FamilyID            string                `json:"familyId" xml:"familyId"`
+	PriorityApplication *PriorityApplication  `json:"priorityApplication,omitempty" xml:"priorityApplication,omitempty"`
+	Members             *[]Patent             `json:"members,omitempty" xml:"members>member,omitempty"`
+	ExternalReferences  *[]ExternalReference  `json:"externalReferences,omitempty" xml:"externalReferences>reference,omitempty"`
+}
+
+// PatentAssertion represents a patent assertion on a component or service
+type PatentAssertion struct {
+	BOMRef        string                 `json:"bom-ref,omitempty" xml:"bom-ref,attr,omitempty"`
+	PatentRefs    *[]BOMReference        `json:"patentRefs,omitempty" xml:"patentRefs>patentRef,omitempty"`
+	AssertionType PatentAssertionType    `json:"assertionType" xml:"assertionType"`
+	Asserter      *OrganizationalEntity  `json:"asserter" xml:"asserter"`
+	Notes         string                 `json:"notes,omitempty" xml:"notes,omitempty"`
+}
+
+// PatentAssertionType represents the type of patent assertion
+type PatentAssertionType string
+
+const (
+	PatentAssertionTypeOwnership           PatentAssertionType = "ownership"
+	PatentAssertionTypeLicense             PatentAssertionType = "license"
+	PatentAssertionTypeThirdPartyClaim     PatentAssertionType = "third-party-claim"
+	PatentAssertionTypeStandardsInclusion  PatentAssertionType = "standards-inclusion"
+	PatentAssertionTypePriorArt            PatentAssertionType = "prior-art"
+	PatentAssertionTypeExclusiveRights     PatentAssertionType = "exclusive-rights"
+	PatentAssertionTypeNonAssertion        PatentAssertionType = "non-assertion"
+	PatentAssertionTypeResearchOrEvaluation PatentAssertionType = "research-or-evaluation"
+)
+
+// PriorityApplication represents priority application details
+type PriorityApplication struct {
+	ApplicationNumber string `json:"applicationNumber" xml:"applicationNumber"`
+	Jurisdiction      string `json:"jurisdiction" xml:"jurisdiction"`
+	FilingDate        string `json:"filingDate" xml:"filingDate"`
+}
+
+// DistributionConstraints represents distribution constraints for a BOM
+type DistributionConstraints struct {
+	TLP TLPClassification `json:"tlp,omitempty" xml:"tlp,omitempty"`
+}
+
+// TLPClassification represents Traffic Light Protocol classification
+type TLPClassification string
+
+const (
+	TLPClassificationClear           TLPClassification = "CLEAR"
+	TLPClassificationGreen           TLPClassification = "GREEN"
+	TLPClassificationAmber           TLPClassification = "AMBER"
+	TLPClassificationAmberAndStrict  TLPClassification = "AMBER+STRICT"
+	TLPClassificationRed             TLPClassification = "RED"
+)
+
+// IKEv2Auth represents IKEv2 Authentication method
+type IKEv2Auth struct {
+	Name      string `json:"name,omitempty" xml:"name,omitempty"`
+	Algorithm string `json:"algorithm,omitempty" xml:"algorithm,omitempty"`
+}
+
+// IKEv2Enc represents IKEv2 Encryption algorithm
+type IKEv2Enc struct {
+	Name      string `json:"name,omitempty" xml:"name,omitempty"`
+	KeyLength int    `json:"keyLength,omitempty" xml:"keyLength,omitempty"`
+	Algorithm string `json:"algorithm,omitempty" xml:"algorithm,omitempty"`
+}
+
+// IKEv2Integ represents IKEv2 Integrity algorithm
+type IKEv2Integ struct {
+	Name      string `json:"name,omitempty" xml:"name,omitempty"`
+	Algorithm string `json:"algorithm,omitempty" xml:"algorithm,omitempty"`
+}
+
+// IKEv2Ke represents IKEv2 Key Exchange method
+type IKEv2Ke struct {
+	Group     int    `json:"group,omitempty" xml:"group,omitempty"`
+	Algorithm string `json:"algorithm,omitempty" xml:"algorithm,omitempty"`
+}
+
+// IKEv2Prf represents IKEv2 Pseudorandom Function
+type IKEv2Prf struct {
+	Name      string `json:"name,omitempty" xml:"name,omitempty"`
+	Algorithm string `json:"algorithm,omitempty" xml:"algorithm,omitempty"`
+}
+
+// RelatedCryptographicAsset represents a related cryptographic asset
+type RelatedCryptographicAsset struct {
+	Type string `json:"type,omitempty" xml:"type,omitempty"`
+	Ref  string `json:"ref,omitempty" xml:"ref,omitempty"`
+}
+
+// CertificateState represents the lifecycle state of a certificate
+type CertificateState struct {
+	// Predefined state fields
+	State  CertificateStateType `json:"state,omitempty" xml:"state,omitempty"`
+	Reason string               `json:"reason,omitempty" xml:"reason,omitempty"`
+	// Custom state fields
+	Name        string `json:"name,omitempty" xml:"name,omitempty"`
+	Description string `json:"description,omitempty" xml:"description,omitempty"`
+}
+
+// CertificateStateType represents predefined certificate lifecycle states
+type CertificateStateType string
+
+const (
+	CertificateStatePreActivation CertificateStateType = "pre-activation"
+	CertificateStateActive        CertificateStateType = "active"
+	CertificateStateSuspended     CertificateStateType = "suspended"
+	CertificateStateDeactivated   CertificateStateType = "deactivated"
+	CertificateStateRevoked       CertificateStateType = "revoked"
+	CertificateStateDestroyed     CertificateStateType = "destroyed"
+)
+
+// CertificateExtension represents a certificate extension field
+type CertificateExtension struct {
+	// Common extension fields
+	CommonExtensionName  CertificateExtensionName `json:"commonExtensionName,omitempty" xml:"commonExtensionName,omitempty"`
+	CommonExtensionValue string                   `json:"commonExtensionValue,omitempty" xml:"commonExtensionValue,omitempty"`
+	// Custom extension fields
+	CustomExtensionName  string `json:"customExtensionName,omitempty" xml:"customExtensionName,omitempty"`
+	CustomExtensionValue string `json:"customExtensionValue,omitempty" xml:"customExtensionValue,omitempty"`
+}
+
+// CertificateExtensionName represents common certificate extension names
+type CertificateExtensionName string
+
+const (
+	CertExtBasicConstraints           CertificateExtensionName = "basicConstraints"
+	CertExtKeyUsage                   CertificateExtensionName = "keyUsage"
+	CertExtExtendedKeyUsage           CertificateExtensionName = "extendedKeyUsage"
+	CertExtSubjectAlternativeName     CertificateExtensionName = "subjectAlternativeName"
+	CertExtAuthorityKeyIdentifier     CertificateExtensionName = "authorityKeyIdentifier"
+	CertExtSubjectKeyIdentifier       CertificateExtensionName = "subjectKeyIdentifier"
+	CertExtAuthorityInformationAccess CertificateExtensionName = "authorityInformationAccess"
+	CertExtCertificatePolicies        CertificateExtensionName = "certificatePolicies"
+	CertExtCRLDistributionPoints      CertificateExtensionName = "crlDistributionPoints"
+	CertExtSignedCertificateTimestamp CertificateExtensionName = "signedCertificateTimestamp"
+)

--- a/cyclonedx.go
+++ b/cyclonedx.go
@@ -169,25 +169,25 @@ type CallstackFrame struct {
 }
 
 type CertificateProperties struct {
-	SerialNumber              string                           `json:"serialNumber,omitempty" xml:"serialNumber,omitempty"`
-	SubjectName               string                           `json:"subjectName,omitempty" xml:"subjectName,omitempty"`
-	IssuerName                string                           `json:"issuerName,omitempty" xml:"issuerName,omitempty"`
-	NotValidBefore            string                           `json:"notValidBefore,omitempty" xml:"notValidBefore,omitempty"`
-	NotValidAfter             string                           `json:"notValidAfter,omitempty" xml:"notValidAfter,omitempty"`
-	SignatureAlgorithmRef     BOMReference                     `json:"signatureAlgorithmRef,omitempty" xml:"signatureAlgorithmRef,omitempty"` // Deprecated in 1.7: use RelatedCryptographicAssets
-	SubjectPublicKeyRef       BOMReference                     `json:"subjectPublicKeyRef,omitempty" xml:"subjectPublicKeyRef,omitempty"`     // Deprecated in 1.7: use RelatedCryptographicAssets
-	CertificateFormat         string                           `json:"certificateFormat,omitempty" xml:"certificateFormat,omitempty"`
-	CertificateExtension      string                           `json:"certificateExtension,omitempty" xml:"certificateExtension,omitempty"`           // Deprecated in 1.7: use CertificateFileExtension
-	CertificateFileExtension  string                           `json:"certificateFileExtension,omitempty" xml:"certificateFileExtension,omitempty"`   // New in 1.7
-	Fingerprint               *Hash                            `json:"fingerprint,omitempty" xml:"fingerprint,omitempty"`                             // New in 1.7
-	CertificateState          *[]CertificateState              `json:"certificateState,omitempty" xml:"certificateState>state,omitempty"`             // New in 1.7
-	CertificateExtensions     *[]CertificateExtension          `json:"certificateExtensions,omitempty" xml:"certificateExtensions>extension,omitempty"` // New in 1.7
-	RelatedCryptographicAssets *[]RelatedCryptographicAsset    `json:"relatedCryptographicAssets,omitempty" xml:"relatedCryptographicAssets>relatedCryptographicAsset,omitempty"` // New in 1.7
-	CreationDate              string                           `json:"creationDate,omitempty" xml:"creationDate,omitempty"`               // New in 1.7
-	ActivationDate            string                           `json:"activationDate,omitempty" xml:"activationDate,omitempty"`           // New in 1.7
-	DeactivationDate          string                           `json:"deactivationDate,omitempty" xml:"deactivationDate,omitempty"`       // New in 1.7
-	RevocationDate            string                           `json:"revocationDate,omitempty" xml:"revocationDate,omitempty"`           // New in 1.7
-	DestructionDate           string                           `json:"destructionDate,omitempty" xml:"destructionDate,omitempty"`         // New in 1.7
+	SerialNumber               string                       `json:"serialNumber,omitempty" xml:"serialNumber,omitempty"`
+	SubjectName                string                       `json:"subjectName,omitempty" xml:"subjectName,omitempty"`
+	IssuerName                 string                       `json:"issuerName,omitempty" xml:"issuerName,omitempty"`
+	NotValidBefore             string                       `json:"notValidBefore,omitempty" xml:"notValidBefore,omitempty"`
+	NotValidAfter              string                       `json:"notValidAfter,omitempty" xml:"notValidAfter,omitempty"`
+	SignatureAlgorithmRef      BOMReference                 `json:"signatureAlgorithmRef,omitempty" xml:"signatureAlgorithmRef,omitempty"` // Deprecated in 1.7: use RelatedCryptographicAssets
+	SubjectPublicKeyRef        BOMReference                 `json:"subjectPublicKeyRef,omitempty" xml:"subjectPublicKeyRef,omitempty"`     // Deprecated in 1.7: use RelatedCryptographicAssets
+	CertificateFormat          string                       `json:"certificateFormat,omitempty" xml:"certificateFormat,omitempty"`
+	CertificateExtension       string                       `json:"certificateExtension,omitempty" xml:"certificateExtension,omitempty"`                                       // Deprecated in 1.7: use CertificateFileExtension
+	CertificateFileExtension   string                       `json:"certificateFileExtension,omitempty" xml:"certificateFileExtension,omitempty"`                               // New in 1.7
+	Fingerprint                *Hash                        `json:"fingerprint,omitempty" xml:"fingerprint,omitempty"`                                                         // New in 1.7
+	CertificateState           *[]CertificateState          `json:"certificateState,omitempty" xml:"certificateState>state,omitempty"`                                         // New in 1.7
+	CertificateExtensions      *[]CertificateExtension      `json:"certificateExtensions,omitempty" xml:"certificateExtensions>extension,omitempty"`                           // New in 1.7
+	RelatedCryptographicAssets *[]RelatedCryptographicAsset `json:"relatedCryptographicAssets,omitempty" xml:"relatedCryptographicAssets>relatedCryptographicAsset,omitempty"` // New in 1.7
+	CreationDate               string                       `json:"creationDate,omitempty" xml:"creationDate,omitempty"`                                                       // New in 1.7
+	ActivationDate             string                       `json:"activationDate,omitempty" xml:"activationDate,omitempty"`                                                   // New in 1.7
+	DeactivationDate           string                       `json:"deactivationDate,omitempty" xml:"deactivationDate,omitempty"`                                               // New in 1.7
+	RevocationDate             string                       `json:"revocationDate,omitempty" xml:"revocationDate,omitempty"`                                                   // New in 1.7
+	DestructionDate            string                       `json:"destructionDate,omitempty" xml:"destructionDate,omitempty"`                                                 // New in 1.7
 }
 
 type Claim struct {
@@ -203,11 +203,11 @@ type Claim struct {
 }
 
 type CipherSuite struct {
-	Name                 string          `json:"name,omitempty" xml:"name,omitempty"`
-	Algorithms           *[]BOMReference `json:"algorithms,omitempty" xml:"algorithms,omitempty"`
-	Identifiers          *[]string       `json:"identifiers,omitempty" xml:"identifiers,omitempty"`
-	TLSGroups            *[]string       `json:"tlsGroups,omitempty" xml:"tlsGroups>group,omitempty"`
-	TLSSignatureSchemes  *[]string       `json:"tlsSignatureSchemes,omitempty" xml:"tlsSignatureSchemes>scheme,omitempty"`
+	Name                string          `json:"name,omitempty" xml:"name,omitempty"`
+	Algorithms          *[]BOMReference `json:"algorithms,omitempty" xml:"algorithms,omitempty"`
+	Identifiers         *[]string       `json:"identifiers,omitempty" xml:"identifiers,omitempty"`
+	TLSGroups           *[]string       `json:"tlsGroups,omitempty" xml:"tlsGroups>group,omitempty"`
+	TLSSignatureSchemes *[]string       `json:"tlsSignatureSchemes,omitempty" xml:"tlsSignatureSchemes>scheme,omitempty"`
 }
 
 type ComponentType string
@@ -506,12 +506,12 @@ type CryptoProperties struct {
 }
 
 type CryptoProtocolProperties struct {
-	Type                       CryptoProtocolType            `json:"type,omitempty" xml:"type,omitempty"`
-	Version                    string                        `json:"version,omitempty" xml:"version,omitempty"`
-	CipherSuites               *[]CipherSuite                `json:"cipherSuites,omitempty" xml:"cipherSuites,omitempty"`
-	IKEv2TransformTypes        *IKEv2TransformTypes          `json:"ikev2TransformTypes,omitempty" xml:"ikev2TransformTypes,omitempty"`
-	CryptoRefArray             *[]BOMReference               `json:"cryptoRefArray,omitempty" xml:"cryptoRefArray,omitempty"`
-	RelatedCryptographicAssets *[]RelatedCryptographicAsset  `json:"relatedCryptographicAssets,omitempty" xml:"relatedCryptographicAssets>relatedCryptographicAsset,omitempty"` // New in 1.7
+	Type                       CryptoProtocolType           `json:"type,omitempty" xml:"type,omitempty"`
+	Version                    string                       `json:"version,omitempty" xml:"version,omitempty"`
+	CipherSuites               *[]CipherSuite               `json:"cipherSuites,omitempty" xml:"cipherSuites,omitempty"`
+	IKEv2TransformTypes        *IKEv2TransformTypes         `json:"ikev2TransformTypes,omitempty" xml:"ikev2TransformTypes,omitempty"`
+	CryptoRefArray             *[]BOMReference              `json:"cryptoRefArray,omitempty" xml:"cryptoRefArray,omitempty"`
+	RelatedCryptographicAssets *[]RelatedCryptographicAsset `json:"relatedCryptographicAssets,omitempty" xml:"relatedCryptographicAssets>relatedCryptographicAsset,omitempty"` // New in 1.7
 }
 
 type CryptoProtocolType string
@@ -779,20 +779,20 @@ type Hash struct {
 type HashAlgorithm string
 
 const (
-	HashAlgoMD5           HashAlgorithm = "MD5"
-	HashAlgoSHA1          HashAlgorithm = "SHA-1"
-	HashAlgoSHA256        HashAlgorithm = "SHA-256"
-	HashAlgoSHA384        HashAlgorithm = "SHA-384"
-	HashAlgoSHA512        HashAlgorithm = "SHA-512"
-	HashAlgoSHA3_256      HashAlgorithm = "SHA3-256"
-	HashAlgoSHA3_384      HashAlgorithm = "SHA3-384"
-	HashAlgoSHA3_512      HashAlgorithm = "SHA3-512"
-	HashAlgoBlake2b_256   HashAlgorithm = "BLAKE2b-256"
-	HashAlgoBlake2b_384   HashAlgorithm = "BLAKE2b-384"
-	HashAlgoBlake2b_512   HashAlgorithm = "BLAKE2b-512"
-	HashAlgoBlake3        HashAlgorithm = "BLAKE3"
-	HashAlgoStreebog256   HashAlgorithm = "Streebog-256"
-	HashAlgoStreebog512   HashAlgorithm = "Streebog-512"
+	HashAlgoMD5         HashAlgorithm = "MD5"
+	HashAlgoSHA1        HashAlgorithm = "SHA-1"
+	HashAlgoSHA256      HashAlgorithm = "SHA-256"
+	HashAlgoSHA384      HashAlgorithm = "SHA-384"
+	HashAlgoSHA512      HashAlgorithm = "SHA-512"
+	HashAlgoSHA3_256    HashAlgorithm = "SHA3-256"
+	HashAlgoSHA3_384    HashAlgorithm = "SHA3-384"
+	HashAlgoSHA3_512    HashAlgorithm = "SHA3-512"
+	HashAlgoBlake2b_256 HashAlgorithm = "BLAKE2b-256"
+	HashAlgoBlake2b_384 HashAlgorithm = "BLAKE2b-384"
+	HashAlgoBlake2b_512 HashAlgorithm = "BLAKE2b-512"
+	HashAlgoBlake3      HashAlgorithm = "BLAKE3"
+	HashAlgoStreebog256 HashAlgorithm = "Streebog-256"
+	HashAlgoStreebog512 HashAlgorithm = "Streebog-512"
 )
 
 type IdentifiableAction struct {
@@ -993,17 +993,17 @@ func (mt MediaType) WithVersion(specVersion SpecVersion) (string, error) {
 }
 
 type Metadata struct {
-	Timestamp    string                   `json:"timestamp,omitempty" xml:"timestamp,omitempty"`
-	Lifecycles   *[]Lifecycle             `json:"lifecycles,omitempty" xml:"lifecycles>lifecycle,omitempty"`
-	Tools        *ToolsChoice             `json:"tools,omitempty" xml:"tools,omitempty"`
-	Authors      *[]OrganizationalContact `json:"authors,omitempty" xml:"authors>author,omitempty"`
-	Component    *Component               `json:"component,omitempty" xml:"component,omitempty"`
-	Manufacture  *OrganizationalEntity    `json:"manufacture,omitempty" xml:"manufacture,omitempty"` // Deprecated: Use Component Manufacturer instead.
-	Manufacturer             *OrganizationalEntity     `json:"manufacturer,omitempty" xml:"manufacturer,omitempty"`
-	Supplier                 *OrganizationalEntity     `json:"supplier,omitempty" xml:"supplier,omitempty"`
-	Licenses                 *Licenses                 `json:"licenses,omitempty" xml:"licenses,omitempty"`
-	Properties               *[]Property               `json:"properties,omitempty" xml:"properties>property,omitempty"`
-	DistributionConstraints  *DistributionConstraints  `json:"distributionConstraints,omitempty" xml:"distributionConstraints,omitempty"`
+	Timestamp               string                   `json:"timestamp,omitempty" xml:"timestamp,omitempty"`
+	Lifecycles              *[]Lifecycle             `json:"lifecycles,omitempty" xml:"lifecycles>lifecycle,omitempty"`
+	Tools                   *ToolsChoice             `json:"tools,omitempty" xml:"tools,omitempty"`
+	Authors                 *[]OrganizationalContact `json:"authors,omitempty" xml:"authors>author,omitempty"`
+	Component               *Component               `json:"component,omitempty" xml:"component,omitempty"`
+	Manufacture             *OrganizationalEntity    `json:"manufacture,omitempty" xml:"manufacture,omitempty"` // Deprecated: Use Component Manufacturer instead.
+	Manufacturer            *OrganizationalEntity    `json:"manufacturer,omitempty" xml:"manufacturer,omitempty"`
+	Supplier                *OrganizationalEntity    `json:"supplier,omitempty" xml:"supplier,omitempty"`
+	Licenses                *Licenses                `json:"licenses,omitempty" xml:"licenses,omitempty"`
+	Properties              *[]Property              `json:"properties,omitempty" xml:"properties>property,omitempty"`
+	DistributionConstraints *DistributionConstraints `json:"distributionConstraints,omitempty" xml:"distributionConstraints,omitempty"`
 }
 
 type MLDatasetChoice struct {
@@ -1233,20 +1233,20 @@ type Property struct {
 }
 
 type RelatedCryptoMaterialProperties struct {
-	Type                       RelatedCryptoMaterialType     `json:"type,omitempty" xml:"type,omitempty"`
-	ID                         string                        `json:"id,omitempty" xml:"id,omitempty"`
-	State                      CryptoKeyState                `json:"state,omitempty" xml:"state,omitempty"`
-	AlgorithmRef               BOMReference                  `json:"algorithmRef,omitempty" xml:"algorithmRef,omitempty"` // Deprecated in 1.7: use RelatedCryptographicAssets
-	CreationDate               string                        `json:"creationDate,omitempty" xml:"creationDate,omitempty"`
-	ActivationDate             string                        `json:"activationDate,omitempty" xml:"activationDate,omitempty"`
-	UpdateDate                 string                        `json:"updateDate,omitempty" xml:"updateDate,omitempty"`
-	ExpirationDate             string                        `json:"expirationDate,omitempty" xml:"expirationDate,omitempty"`
-	Value                      string                        `json:"value,omitempty" xml:"value,omitempty"`
-	Size                       *int                          `json:"size,omitempty" xml:"size,omitempty"`
-	Format                     string                        `json:"format,omitempty" xml:"format,omitempty"`
-	SecuredBy                  *SecuredBy                    `json:"securedBy,omitempty" xml:"securedBy,omitempty"`
-	Fingerprint                *Hash                         `json:"fingerprint,omitempty" xml:"fingerprint,omitempty"`                                                                                 // New in 1.7
-	RelatedCryptographicAssets *[]RelatedCryptographicAsset  `json:"relatedCryptographicAssets,omitempty" xml:"relatedCryptographicAssets>relatedCryptographicAsset,omitempty"` // New in 1.7
+	Type                       RelatedCryptoMaterialType    `json:"type,omitempty" xml:"type,omitempty"`
+	ID                         string                       `json:"id,omitempty" xml:"id,omitempty"`
+	State                      CryptoKeyState               `json:"state,omitempty" xml:"state,omitempty"`
+	AlgorithmRef               BOMReference                 `json:"algorithmRef,omitempty" xml:"algorithmRef,omitempty"` // Deprecated in 1.7: use RelatedCryptographicAssets
+	CreationDate               string                       `json:"creationDate,omitempty" xml:"creationDate,omitempty"`
+	ActivationDate             string                       `json:"activationDate,omitempty" xml:"activationDate,omitempty"`
+	UpdateDate                 string                       `json:"updateDate,omitempty" xml:"updateDate,omitempty"`
+	ExpirationDate             string                       `json:"expirationDate,omitempty" xml:"expirationDate,omitempty"`
+	Value                      string                       `json:"value,omitempty" xml:"value,omitempty"`
+	Size                       *int                         `json:"size,omitempty" xml:"size,omitempty"`
+	Format                     string                       `json:"format,omitempty" xml:"format,omitempty"`
+	SecuredBy                  *SecuredBy                   `json:"securedBy,omitempty" xml:"securedBy,omitempty"`
+	Fingerprint                *Hash                        `json:"fingerprint,omitempty" xml:"fingerprint,omitempty"`                                                         // New in 1.7
+	RelatedCryptographicAssets *[]RelatedCryptographicAsset `json:"relatedCryptographicAssets,omitempty" xml:"relatedCryptographicAssets>relatedCryptographicAsset,omitempty"` // New in 1.7
 }
 
 type RelatedCryptoMaterialType string
@@ -1663,63 +1663,63 @@ type Workflow struct {
 
 // Citation represents an attribution of data to a source
 type Citation struct {
-	BOMRef       string                   `json:"bom-ref,omitempty" xml:"bom-ref,attr,omitempty"`
-	Pointers     *[]string                `json:"pointers,omitempty" xml:"pointers>pointer,omitempty"`
-	Expressions  *[]string                `json:"expressions,omitempty" xml:"expressions>expression,omitempty"`
-	Timestamp    string                   `json:"timestamp,omitempty" xml:"timestamp,omitempty"`
-	AttributedTo *OrganizationalEntity    `json:"attributedTo,omitempty" xml:"attributedTo,omitempty"`
-	Process      string                   `json:"process,omitempty" xml:"process,omitempty"`
-	Note         string                   `json:"note,omitempty" xml:"note,omitempty"`
-	Signature    *JSFSignature            `json:"signature,omitempty" xml:"-"`
+	BOMRef       string                `json:"bom-ref,omitempty" xml:"bom-ref,attr,omitempty"`
+	Pointers     *[]string             `json:"pointers,omitempty" xml:"pointers>pointer,omitempty"`
+	Expressions  *[]string             `json:"expressions,omitempty" xml:"expressions>expression,omitempty"`
+	Timestamp    string                `json:"timestamp,omitempty" xml:"timestamp,omitempty"`
+	AttributedTo *OrganizationalEntity `json:"attributedTo,omitempty" xml:"attributedTo,omitempty"`
+	Process      string                `json:"process,omitempty" xml:"process,omitempty"`
+	Note         string                `json:"note,omitempty" xml:"note,omitempty"`
+	Signature    *JSFSignature         `json:"signature,omitempty" xml:"-"`
 }
 
 // Patent represents patent information
 type Patent struct {
-	BOMRef                string                      `json:"bom-ref,omitempty" xml:"bom-ref,attr,omitempty"`
-	PatentNumber          string                      `json:"patentNumber" xml:"patentNumber"`
-	ApplicationNumber     string                      `json:"applicationNumber,omitempty" xml:"applicationNumber,omitempty"`
-	Jurisdiction          string                      `json:"jurisdiction" xml:"jurisdiction"`
-	PriorityApplication   *PriorityApplication        `json:"priorityApplication,omitempty" xml:"priorityApplication,omitempty"`
-	PublicationNumber     string                      `json:"publicationNumber,omitempty" xml:"publicationNumber,omitempty"`
-	Title                 string                      `json:"title,omitempty" xml:"title,omitempty"`
-	Abstract              string                      `json:"abstract,omitempty" xml:"abstract,omitempty"`
-	FilingDate            string                      `json:"filingDate,omitempty" xml:"filingDate,omitempty"`
-	GrantDate             string                      `json:"grantDate,omitempty" xml:"grantDate,omitempty"`
-	PatentExpirationDate  string                      `json:"patentExpirationDate,omitempty" xml:"patentExpirationDate,omitempty"`
-	PatentLegalStatus     string                      `json:"patentLegalStatus" xml:"patentLegalStatus"`
-	PatentAssignee        *[]OrganizationalEntity     `json:"patentAssignee,omitempty" xml:"patentAssignee>assignee,omitempty"`
-	ExternalReferences    *[]ExternalReference        `json:"externalReferences,omitempty" xml:"externalReferences>reference,omitempty"`
+	BOMRef               string                  `json:"bom-ref,omitempty" xml:"bom-ref,attr,omitempty"`
+	PatentNumber         string                  `json:"patentNumber" xml:"patentNumber"`
+	ApplicationNumber    string                  `json:"applicationNumber,omitempty" xml:"applicationNumber,omitempty"`
+	Jurisdiction         string                  `json:"jurisdiction" xml:"jurisdiction"`
+	PriorityApplication  *PriorityApplication    `json:"priorityApplication,omitempty" xml:"priorityApplication,omitempty"`
+	PublicationNumber    string                  `json:"publicationNumber,omitempty" xml:"publicationNumber,omitempty"`
+	Title                string                  `json:"title,omitempty" xml:"title,omitempty"`
+	Abstract             string                  `json:"abstract,omitempty" xml:"abstract,omitempty"`
+	FilingDate           string                  `json:"filingDate,omitempty" xml:"filingDate,omitempty"`
+	GrantDate            string                  `json:"grantDate,omitempty" xml:"grantDate,omitempty"`
+	PatentExpirationDate string                  `json:"patentExpirationDate,omitempty" xml:"patentExpirationDate,omitempty"`
+	PatentLegalStatus    string                  `json:"patentLegalStatus" xml:"patentLegalStatus"`
+	PatentAssignee       *[]OrganizationalEntity `json:"patentAssignee,omitempty" xml:"patentAssignee>assignee,omitempty"`
+	ExternalReferences   *[]ExternalReference    `json:"externalReferences,omitempty" xml:"externalReferences>reference,omitempty"`
 }
 
 // PatentFamily represents a patent family grouping
 type PatentFamily struct {
-	BOMRef              string                `json:"bom-ref,omitempty" xml:"bom-ref,attr,omitempty"`
-	FamilyID            string                `json:"familyId" xml:"familyId"`
-	PriorityApplication *PriorityApplication  `json:"priorityApplication,omitempty" xml:"priorityApplication,omitempty"`
-	Members             *[]Patent             `json:"members,omitempty" xml:"members>member,omitempty"`
-	ExternalReferences  *[]ExternalReference  `json:"externalReferences,omitempty" xml:"externalReferences>reference,omitempty"`
+	BOMRef              string               `json:"bom-ref,omitempty" xml:"bom-ref,attr,omitempty"`
+	FamilyID            string               `json:"familyId" xml:"familyId"`
+	PriorityApplication *PriorityApplication `json:"priorityApplication,omitempty" xml:"priorityApplication,omitempty"`
+	Members             *[]Patent            `json:"members,omitempty" xml:"members>member,omitempty"`
+	ExternalReferences  *[]ExternalReference `json:"externalReferences,omitempty" xml:"externalReferences>reference,omitempty"`
 }
 
 // PatentAssertion represents a patent assertion on a component or service
 type PatentAssertion struct {
-	BOMRef        string                 `json:"bom-ref,omitempty" xml:"bom-ref,attr,omitempty"`
-	PatentRefs    *[]BOMReference        `json:"patentRefs,omitempty" xml:"patentRefs>patentRef,omitempty"`
-	AssertionType PatentAssertionType    `json:"assertionType" xml:"assertionType"`
-	Asserter      *OrganizationalEntity  `json:"asserter" xml:"asserter"`
-	Notes         string                 `json:"notes,omitempty" xml:"notes,omitempty"`
+	BOMRef        string                `json:"bom-ref,omitempty" xml:"bom-ref,attr,omitempty"`
+	PatentRefs    *[]BOMReference       `json:"patentRefs,omitempty" xml:"patentRefs>patentRef,omitempty"`
+	AssertionType PatentAssertionType   `json:"assertionType" xml:"assertionType"`
+	Asserter      *OrganizationalEntity `json:"asserter" xml:"asserter"`
+	Notes         string                `json:"notes,omitempty" xml:"notes,omitempty"`
 }
 
 // PatentAssertionType represents the type of patent assertion
 type PatentAssertionType string
 
 const (
-	PatentAssertionTypeOwnership           PatentAssertionType = "ownership"
-	PatentAssertionTypeLicense             PatentAssertionType = "license"
-	PatentAssertionTypeThirdPartyClaim     PatentAssertionType = "third-party-claim"
-	PatentAssertionTypeStandardsInclusion  PatentAssertionType = "standards-inclusion"
-	PatentAssertionTypePriorArt            PatentAssertionType = "prior-art"
-	PatentAssertionTypeExclusiveRights     PatentAssertionType = "exclusive-rights"
-	PatentAssertionTypeNonAssertion        PatentAssertionType = "non-assertion"
+	PatentAssertionTypeOwnership            PatentAssertionType = "ownership"
+	PatentAssertionTypeLicense              PatentAssertionType = "license"
+	PatentAssertionTypeThirdPartyClaim      PatentAssertionType = "third-party-claim"
+	PatentAssertionTypeStandardsInclusion   PatentAssertionType = "standards-inclusion"
+	PatentAssertionTypePriorArt             PatentAssertionType = "prior-art"
+	PatentAssertionTypeExclusiveRights      PatentAssertionType = "exclusive-rights"
+	PatentAssertionTypeNonAssertion         PatentAssertionType = "non-assertion"
 	PatentAssertionTypeResearchOrEvaluation PatentAssertionType = "research-or-evaluation"
 )
 
@@ -1739,11 +1739,11 @@ type DistributionConstraints struct {
 type TLPClassification string
 
 const (
-	TLPClassificationClear           TLPClassification = "CLEAR"
-	TLPClassificationGreen           TLPClassification = "GREEN"
-	TLPClassificationAmber           TLPClassification = "AMBER"
-	TLPClassificationAmberAndStrict  TLPClassification = "AMBER+STRICT"
-	TLPClassificationRed             TLPClassification = "RED"
+	TLPClassificationClear          TLPClassification = "CLEAR"
+	TLPClassificationGreen          TLPClassification = "GREEN"
+	TLPClassificationAmber          TLPClassification = "AMBER"
+	TLPClassificationAmberAndStrict TLPClassification = "AMBER+STRICT"
+	TLPClassificationRed            TLPClassification = "RED"
 )
 
 // IKEv2Auth represents IKEv2 Authentication method

--- a/cyclonedx.go
+++ b/cyclonedx.go
@@ -670,18 +670,27 @@ type Event struct {
 }
 
 type Evidence struct {
-	Identity    *[]EvidenceIdentity   `json:"identity,omitempty" xml:"-"`
-	Occurrences *[]EvidenceOccurrence `json:"occurrences,omitempty" xml:"-"`
-	Callstack   *Callstack            `json:"callstack,omitempty" xml:"-"`
-	Licenses    *Licenses             `json:"licenses,omitempty" xml:"-"`
-	Copyright   *[]Copyright          `json:"copyright,omitempty" xml:"-"`
+	Identity    *EvidenceIdentityChoice `json:"identity,omitempty" xml:"-"`
+	Occurrences *[]EvidenceOccurrence   `json:"occurrences,omitempty" xml:"-"`
+	Callstack   *Callstack              `json:"callstack,omitempty" xml:"-"`
+	Licenses    *Licenses               `json:"licenses,omitempty" xml:"-"`
+	Copyright   *[]Copyright            `json:"copyright,omitempty" xml:"-"`
+}
+
+// EvidenceIdentityChoice represents the oneOf identity field in component evidence.
+// In 1.7, identity can be either an array of EvidenceIdentity objects or a single
+// EvidenceIdentity object (deprecated). Encoding or decoding with both set will raise an error.
+type EvidenceIdentityChoice struct {
+	Identity   *EvidenceIdentity   `json:"-" xml:"-"` // Deprecated: Use Identities
+	Identities *[]EvidenceIdentity `json:"-" xml:"-"`
 }
 
 type EvidenceIdentity struct {
-	Field      EvidenceIdentityFieldType `json:"field,omitempty" xml:"field,omitempty"`
-	Confidence *float32                  `json:"confidence,omitempty" xml:"confidence,omitempty"`
-	Methods    *[]EvidenceIdentityMethod `json:"methods,omitempty" xml:"methods>method,omitempty"`
-	Tools      *[]BOMReference           `json:"tools,omitempty" xml:"tools>tool,omitempty"`
+	Field          EvidenceIdentityFieldType `json:"field,omitempty" xml:"field,omitempty"`
+	Confidence     *float32                  `json:"confidence,omitempty" xml:"confidence,omitempty"`
+	ConcludedValue string                    `json:"concludedValue,omitempty" xml:"concludedValue,omitempty"`
+	Methods        *[]EvidenceIdentityMethod `json:"methods,omitempty" xml:"methods>method,omitempty"`
+	Tools          *[]BOMReference           `json:"tools,omitempty" xml:"tools>tool,omitempty"`
 }
 
 type EvidenceIdentityFieldType string

--- a/cyclonedx.go
+++ b/cyclonedx.go
@@ -1840,14 +1840,25 @@ type RelatedCryptographicAsset struct {
 	Ref  string `json:"ref,omitempty" xml:"ref,omitempty"`
 }
 
-// CertificateState represents the lifecycle state of a certificate
+// CertificateState represents the lifecycle state of a certificate.
+// It is a oneOf of either a PredefinedCertificateState or a CustomCertificateState.
+// Encoding or decoding a CertificateState with both options present will raise an error.
 type CertificateState struct {
-	// Predefined state fields
-	State  CertificateStateType `json:"state,omitempty" xml:"state,omitempty"`
+	Predefined *PredefinedCertificateState `json:"-" xml:"-"`
+	Custom     *CustomCertificateState     `json:"-" xml:"-"`
+}
+
+// PredefinedCertificateState represents a certificate state using a predefined enum value.
+type PredefinedCertificateState struct {
+	State  CertificateStateType `json:"state" xml:"state"`
 	Reason string               `json:"reason,omitempty" xml:"reason,omitempty"`
-	// Custom state fields
-	Name        string `json:"name,omitempty" xml:"name,omitempty"`
+}
+
+// CustomCertificateState represents a certificate state using a custom name and description.
+type CustomCertificateState struct {
+	Name        string `json:"name" xml:"name"`
 	Description string `json:"description,omitempty" xml:"description,omitempty"`
+	Reason      string `json:"reason,omitempty" xml:"reason,omitempty"`
 }
 
 // CertificateStateType represents predefined certificate lifecycle states
@@ -1862,14 +1873,24 @@ const (
 	CertificateStateDestroyed     CertificateStateType = "destroyed"
 )
 
-// CertificateExtension represents a certificate extension field
+// CertificateExtension represents a certificate extension field.
+// It is a oneOf of either a CommonCertificateExtension or a CustomCertificateExtension.
+// Encoding or decoding a CertificateExtension with both options present will raise an error.
 type CertificateExtension struct {
-	// Common extension fields
-	CommonExtensionName  CertificateExtensionName `json:"commonExtensionName,omitempty" xml:"commonExtensionName,omitempty"`
-	CommonExtensionValue string                   `json:"commonExtensionValue,omitempty" xml:"commonExtensionValue,omitempty"`
-	// Custom extension fields
-	CustomExtensionName  string `json:"customExtensionName,omitempty" xml:"customExtensionName,omitempty"`
-	CustomExtensionValue string `json:"customExtensionValue,omitempty" xml:"customExtensionValue,omitempty"`
+	Common *CommonCertificateExtension `json:"-" xml:"-"`
+	Custom *CustomCertificateExtension `json:"-" xml:"-"`
+}
+
+// CommonCertificateExtension represents a certificate extension using a predefined name.
+type CommonCertificateExtension struct {
+	Name  CertificateExtensionName `json:"commonExtensionName" xml:"commonExtensionName"`
+	Value string                   `json:"commonExtensionValue,omitempty" xml:"commonExtensionValue,omitempty"`
+}
+
+// CustomCertificateExtension represents a certificate extension using a custom name.
+type CustomCertificateExtension struct {
+	Name  string `json:"customExtensionName" xml:"customExtensionName"`
+	Value string `json:"customExtensionValue,omitempty" xml:"customExtensionValue,omitempty"`
 }
 
 // CertificateExtensionName represents common certificate extension names

--- a/cyclonedx.go
+++ b/cyclonedx.go
@@ -948,7 +948,10 @@ type LicenseChoice struct {
 	License           *License                   `json:"license,omitempty" xml:"-"`
 	Expression        string                     `json:"expression,omitempty" xml:"-"`
 	ExpressionDetails *[]LicenseExpressionDetail `json:"expressionDetails,omitempty" xml:"-"`
-	Acknowledgement   LicenseAcknowledgement     `json:"acknowledgement,omitempty" xml:"-"`
+	Acknowledgement   *LicenseAcknowledgement    `json:"acknowledgement,omitempty" xml:"-"`
+	BOMRef            string                     `json:"bom-ref,omitempty" xml:"-"`
+	Licensing         *Licensing                 `json:"licensing,omitempty" xml:"-"`
+	Properties        *[]Property                `json:"properties,omitempty" xml:"properties>property,omitempty"`
 }
 
 // LicenseExpressionDetail provides details for individual license identifiers within an SPDX expression.

--- a/cyclonedx.go
+++ b/cyclonedx.go
@@ -180,8 +180,8 @@ type CertificateProperties struct {
 	CertificateExtension       string                       `json:"certificateExtension,omitempty" xml:"certificateExtension,omitempty"`                                       // Deprecated in 1.7: use CertificateFileExtension
 	CertificateFileExtension   string                       `json:"certificateFileExtension,omitempty" xml:"certificateFileExtension,omitempty"`                               // New in 1.7
 	Fingerprint                *Hash                        `json:"fingerprint,omitempty" xml:"fingerprint,omitempty"`                                                         // New in 1.7
-	CertificateState           *[]CertificateState          `json:"certificateState,omitempty" xml:"certificateState>state,omitempty"`                                         // New in 1.7
-	CertificateExtensions      *[]CertificateExtension      `json:"certificateExtensions,omitempty" xml:"certificateExtensions>extension,omitempty"`                           // New in 1.7
+	CertificateState           *[]CertificateState          `json:"certificateState,omitempty" xml:"certificateState,omitempty"`                                               // New in 1.7
+	CertificateExtensions      *[]CertificateExtension      `json:"certificateExtensions,omitempty" xml:"certificateExtensions>certificateExtension,omitempty"`                // New in 1.7
 	RelatedCryptographicAssets *[]RelatedCryptographicAsset `json:"relatedCryptographicAssets,omitempty" xml:"relatedCryptographicAssets>relatedCryptographicAsset,omitempty"` // New in 1.7
 	CreationDate               string                       `json:"creationDate,omitempty" xml:"creationDate,omitempty"`                                                       // New in 1.7
 	ActivationDate             string                       `json:"activationDate,omitempty" xml:"activationDate,omitempty"`                                                   // New in 1.7
@@ -207,7 +207,7 @@ type CipherSuite struct {
 	Algorithms          *[]BOMReference `json:"algorithms,omitempty" xml:"algorithms,omitempty"`
 	Identifiers         *[]string       `json:"identifiers,omitempty" xml:"identifiers,omitempty"`
 	TLSGroups           *[]string       `json:"tlsGroups,omitempty" xml:"tlsGroups>group,omitempty"`
-	TLSSignatureSchemes *[]string       `json:"tlsSignatureSchemes,omitempty" xml:"tlsSignatureSchemes>scheme,omitempty"`
+	TLSSignatureSchemes *[]string       `json:"tlsSignatureSchemes,omitempty" xml:"tlsSignatureSchemes>signatureScheme,omitempty"`
 }
 
 type ComponentType string
@@ -1714,7 +1714,7 @@ type Citation struct {
 	Pointers     *[]string             `json:"pointers,omitempty" xml:"pointers>pointer,omitempty"`
 	Expressions  *[]string             `json:"expressions,omitempty" xml:"expressions>expression,omitempty"`
 	Timestamp    string                `json:"timestamp,omitempty" xml:"timestamp,omitempty"`
-	AttributedTo *OrganizationalEntity `json:"attributedTo,omitempty" xml:"attributedTo,omitempty"`
+	AttributedTo *BOMReference         `json:"attributedTo,omitempty" xml:"attributedTo,omitempty"`
 	Process      string                `json:"process,omitempty" xml:"process,omitempty"`
 	Note         string                `json:"note,omitempty" xml:"note,omitempty"`
 	Signature    *JSFSignature         `json:"signature,omitempty" xml:"-"`
@@ -1753,7 +1753,7 @@ type Patent struct {
 	GrantDate            string                  `json:"grantDate,omitempty" xml:"grantDate,omitempty"`
 	PatentExpirationDate string                  `json:"patentExpirationDate,omitempty" xml:"patentExpirationDate,omitempty"`
 	PatentLegalStatus    PatentLegalStatus       `json:"patentLegalStatus" xml:"patentLegalStatus"`
-	PatentAssignee       *[]OrganizationalEntity `json:"patentAssignee,omitempty" xml:"patentAssignee>assignee,omitempty"`
+	PatentAssignee       *[]OrganizationalEntityOrContact `json:"patentAssignee,omitempty" xml:"patentAssignee,omitempty"`
 	ExternalReferences   *[]ExternalReference    `json:"externalReferences,omitempty" xml:"externalReferences>reference,omitempty"`
 }
 
@@ -1762,17 +1762,26 @@ type PatentFamily struct {
 	BOMRef              string               `json:"bom-ref,omitempty" xml:"bom-ref,attr,omitempty"`
 	FamilyID            string               `json:"familyId" xml:"familyId"`
 	PriorityApplication *PriorityApplication `json:"priorityApplication,omitempty" xml:"priorityApplication,omitempty"`
-	Members             *[]Patent            `json:"members,omitempty" xml:"members>member,omitempty"`
+	Members             *[]BOMReference      `json:"members,omitempty" xml:"members>ref,omitempty"`
 	ExternalReferences  *[]ExternalReference `json:"externalReferences,omitempty" xml:"externalReferences>reference,omitempty"`
+}
+
+// AsserterChoice represents the asserter of a patent assertion.
+// It is a oneOf of OrganizationalEntity, OrganizationalContact, or a BOM reference.
+// Encoding or decoding with more than one option set will raise an error.
+type AsserterChoice struct {
+	Organization *OrganizationalEntity  `json:"organization,omitempty" xml:"organization,omitempty"`
+	Individual   *OrganizationalContact `json:"individual,omitempty" xml:"contact,omitempty"`
+	BOMRef       *BOMReference          `json:"ref,omitempty" xml:"ref,omitempty"`
 }
 
 // PatentAssertion represents a patent assertion on a component or service
 type PatentAssertion struct {
-	BOMRef        string                `json:"bom-ref,omitempty" xml:"bom-ref,attr,omitempty"`
-	PatentRefs    *[]BOMReference       `json:"patentRefs,omitempty" xml:"patentRefs>patentRef,omitempty"`
-	AssertionType PatentAssertionType   `json:"assertionType" xml:"assertionType"`
-	Asserter      *OrganizationalEntity `json:"asserter" xml:"asserter"`
-	Notes         string                `json:"notes,omitempty" xml:"notes,omitempty"`
+	BOMRef        string              `json:"bom-ref,omitempty" xml:"bom-ref,attr,omitempty"`
+	PatentRefs    *[]BOMReference     `json:"patentRefs,omitempty" xml:"patentRefs>bom-ref,omitempty"`
+	AssertionType PatentAssertionType `json:"assertionType" xml:"assertionType"`
+	Asserter      *AsserterChoice     `json:"asserter" xml:"asserter"`
+	Notes         string              `json:"notes,omitempty" xml:"notes,omitempty"`
 }
 
 // PatentAssertionType represents the type of patent assertion
@@ -1812,35 +1821,45 @@ const (
 	TLPClassificationRed            TLPClassification = "RED"
 )
 
-// IKEv2Auth represents IKEv2 Authentication method
+// IKEv2Auth represents IKEv2 Authentication method.
+// BOMRef holds the deprecated 1.6 bom-ref string form; Name/Algorithm are the 1.7 structured form.
 type IKEv2Auth struct {
-	Name      string `json:"name,omitempty" xml:"name,omitempty"`
-	Algorithm string `json:"algorithm,omitempty" xml:"algorithm,omitempty"`
+	BOMRef    BOMReference `json:"-" xml:"-"`
+	Name      string       `json:"name,omitempty" xml:"name,omitempty"`
+	Algorithm string       `json:"algorithm,omitempty" xml:"algorithm,omitempty"`
 }
 
-// IKEv2Enc represents IKEv2 Encryption algorithm
+// IKEv2Enc represents IKEv2 Encryption algorithm.
+// BOMRef holds the deprecated 1.6 bom-ref string form; Name/KeyLength/Algorithm are the 1.7 structured form.
 type IKEv2Enc struct {
-	Name      string `json:"name,omitempty" xml:"name,omitempty"`
-	KeyLength *int   `json:"keyLength,omitempty" xml:"keyLength,omitempty"`
-	Algorithm string `json:"algorithm,omitempty" xml:"algorithm,omitempty"`
+	BOMRef    BOMReference `json:"-" xml:"-"`
+	Name      string       `json:"name,omitempty" xml:"name,omitempty"`
+	KeyLength *int         `json:"keyLength,omitempty" xml:"keyLength,omitempty"`
+	Algorithm string       `json:"algorithm,omitempty" xml:"algorithm,omitempty"`
 }
 
-// IKEv2Integ represents IKEv2 Integrity algorithm
+// IKEv2Integ represents IKEv2 Integrity algorithm.
+// BOMRef holds the deprecated 1.6 bom-ref string form; Name/Algorithm are the 1.7 structured form.
 type IKEv2Integ struct {
-	Name      string `json:"name,omitempty" xml:"name,omitempty"`
-	Algorithm string `json:"algorithm,omitempty" xml:"algorithm,omitempty"`
+	BOMRef    BOMReference `json:"-" xml:"-"`
+	Name      string       `json:"name,omitempty" xml:"name,omitempty"`
+	Algorithm string       `json:"algorithm,omitempty" xml:"algorithm,omitempty"`
 }
 
-// IKEv2Ke represents IKEv2 Key Exchange method
+// IKEv2Ke represents IKEv2 Key Exchange method.
+// BOMRef holds the deprecated 1.6 bom-ref string form; Group/Algorithm are the 1.7 structured form.
 type IKEv2Ke struct {
-	Group     *int   `json:"group,omitempty" xml:"group,omitempty"`
-	Algorithm string `json:"algorithm,omitempty" xml:"algorithm,omitempty"`
+	BOMRef    BOMReference `json:"-" xml:"-"`
+	Group     *int         `json:"group,omitempty" xml:"group,omitempty"`
+	Algorithm string       `json:"algorithm,omitempty" xml:"algorithm,omitempty"`
 }
 
-// IKEv2Prf represents IKEv2 Pseudorandom Function
+// IKEv2Prf represents IKEv2 Pseudorandom Function.
+// BOMRef holds the deprecated 1.6 bom-ref string form; Name/Algorithm are the 1.7 structured form.
 type IKEv2Prf struct {
-	Name      string `json:"name,omitempty" xml:"name,omitempty"`
-	Algorithm string `json:"algorithm,omitempty" xml:"algorithm,omitempty"`
+	BOMRef    BOMReference `json:"-" xml:"-"`
+	Name      string       `json:"name,omitempty" xml:"name,omitempty"`
+	Algorithm string       `json:"algorithm,omitempty" xml:"algorithm,omitempty"`
 }
 
 // RelatedCryptographicAsset represents a related cryptographic asset

--- a/cyclonedx.go
+++ b/cyclonedx.go
@@ -1710,14 +1710,14 @@ type Workflow struct {
 
 // Citation represents an attribution of data to a source
 type Citation struct {
-	BOMRef       string                `json:"bom-ref,omitempty" xml:"bom-ref,attr,omitempty"`
-	Pointers     *[]string             `json:"pointers,omitempty" xml:"pointers>pointer,omitempty"`
-	Expressions  *[]string             `json:"expressions,omitempty" xml:"expressions>expression,omitempty"`
-	Timestamp    string                `json:"timestamp,omitempty" xml:"timestamp,omitempty"`
-	AttributedTo *BOMReference         `json:"attributedTo,omitempty" xml:"attributedTo,omitempty"`
-	Process      string                `json:"process,omitempty" xml:"process,omitempty"`
-	Note         string                `json:"note,omitempty" xml:"note,omitempty"`
-	Signature    *JSFSignature         `json:"signature,omitempty" xml:"-"`
+	BOMRef       string        `json:"bom-ref,omitempty" xml:"bom-ref,attr,omitempty"`
+	Pointers     *[]string     `json:"pointers,omitempty" xml:"pointers>pointer,omitempty"`
+	Expressions  *[]string     `json:"expressions,omitempty" xml:"expressions>expression,omitempty"`
+	Timestamp    string        `json:"timestamp,omitempty" xml:"timestamp,omitempty"`
+	AttributedTo *BOMReference `json:"attributedTo,omitempty" xml:"attributedTo,omitempty"`
+	Process      string        `json:"process,omitempty" xml:"process,omitempty"`
+	Note         string        `json:"note,omitempty" xml:"note,omitempty"`
+	Signature    *JSFSignature `json:"signature,omitempty" xml:"-"`
 }
 
 // PatentLegalStatus represents the legal status of a patent per WIPO ST.27.
@@ -1741,20 +1741,20 @@ const (
 
 // Patent represents patent information
 type Patent struct {
-	BOMRef               string                  `json:"bom-ref,omitempty" xml:"bom-ref,attr,omitempty"`
-	PatentNumber         string                  `json:"patentNumber" xml:"patentNumber"`
-	ApplicationNumber    string                  `json:"applicationNumber,omitempty" xml:"applicationNumber,omitempty"`
-	Jurisdiction         string                  `json:"jurisdiction" xml:"jurisdiction"`
-	PriorityApplication  *PriorityApplication    `json:"priorityApplication,omitempty" xml:"priorityApplication,omitempty"`
-	PublicationNumber    string                  `json:"publicationNumber,omitempty" xml:"publicationNumber,omitempty"`
-	Title                string                  `json:"title,omitempty" xml:"title,omitempty"`
-	Abstract             string                  `json:"abstract,omitempty" xml:"abstract,omitempty"`
-	FilingDate           string                  `json:"filingDate,omitempty" xml:"filingDate,omitempty"`
-	GrantDate            string                  `json:"grantDate,omitempty" xml:"grantDate,omitempty"`
-	PatentExpirationDate string                  `json:"patentExpirationDate,omitempty" xml:"patentExpirationDate,omitempty"`
-	PatentLegalStatus    PatentLegalStatus       `json:"patentLegalStatus" xml:"patentLegalStatus"`
+	BOMRef               string                           `json:"bom-ref,omitempty" xml:"bom-ref,attr,omitempty"`
+	PatentNumber         string                           `json:"patentNumber" xml:"patentNumber"`
+	ApplicationNumber    string                           `json:"applicationNumber,omitempty" xml:"applicationNumber,omitempty"`
+	Jurisdiction         string                           `json:"jurisdiction" xml:"jurisdiction"`
+	PriorityApplication  *PriorityApplication             `json:"priorityApplication,omitempty" xml:"priorityApplication,omitempty"`
+	PublicationNumber    string                           `json:"publicationNumber,omitempty" xml:"publicationNumber,omitempty"`
+	Title                string                           `json:"title,omitempty" xml:"title,omitempty"`
+	Abstract             string                           `json:"abstract,omitempty" xml:"abstract,omitempty"`
+	FilingDate           string                           `json:"filingDate,omitempty" xml:"filingDate,omitempty"`
+	GrantDate            string                           `json:"grantDate,omitempty" xml:"grantDate,omitempty"`
+	PatentExpirationDate string                           `json:"patentExpirationDate,omitempty" xml:"patentExpirationDate,omitempty"`
+	PatentLegalStatus    PatentLegalStatus                `json:"patentLegalStatus" xml:"patentLegalStatus"`
 	PatentAssignee       *[]OrganizationalEntityOrContact `json:"patentAssignee,omitempty" xml:"patentAssignee,omitempty"`
-	ExternalReferences   *[]ExternalReference    `json:"externalReferences,omitempty" xml:"externalReferences>reference,omitempty"`
+	ExternalReferences   *[]ExternalReference             `json:"externalReferences,omitempty" xml:"externalReferences>reference,omitempty"`
 }
 
 // PatentFamily represents a patent family grouping

--- a/cyclonedx.go
+++ b/cyclonedx.go
@@ -492,6 +492,7 @@ const (
 	CryptoPrimitiveKEM          CryptoPrimitive = "kem"
 	CryptoPrimitiveAE           CryptoPrimitive = "ae"
 	CryptoPrimitiveCombiner     CryptoPrimitive = "combiner"
+	CryptoPrimitiveKeyWrap      CryptoPrimitive = "key-wrap"
 	CryptoPrimitiveOther        CryptoPrimitive = "other"
 	CryptoPrimitiveUnknown      CryptoPrimitive = "unknown"
 )
@@ -517,23 +518,29 @@ type CryptoProtocolProperties struct {
 type CryptoProtocolType string
 
 const (
-	CryptoProtocolTypeTLS     CryptoProtocolType = "tls"
-	CryptoProtocolTypeSSH     CryptoProtocolType = "ssh"
-	CryptoProtocolTypeIPSec   CryptoProtocolType = "ipsec"
-	CryptoProtocolTypeIKE     CryptoProtocolType = "ike"
-	CryptoProtocolTypeSSTP    CryptoProtocolType = "sstp"
-	CryptoProtocolTypeWPA     CryptoProtocolType = "wpa"
-	CryptoProtocolTypeOther   CryptoProtocolType = "other"
-	CryptoProtocolTypeUnknown CryptoProtocolType = "unknown"
+	CryptoProtocolTypeTLS         CryptoProtocolType = "tls"
+	CryptoProtocolTypeSSH         CryptoProtocolType = "ssh"
+	CryptoProtocolTypeIPSec       CryptoProtocolType = "ipsec"
+	CryptoProtocolTypeIKE         CryptoProtocolType = "ike"
+	CryptoProtocolTypeSSTP        CryptoProtocolType = "sstp"
+	CryptoProtocolTypeWPA         CryptoProtocolType = "wpa"
+	CryptoProtocolTypeDTLS        CryptoProtocolType = "dtls"
+	CryptoProtocolTypeQUIC        CryptoProtocolType = "quic"
+	CryptoProtocolTypeEAPAKA      CryptoProtocolType = "eap-aka"
+	CryptoProtocolTypeEAPAKAPrime CryptoProtocolType = "eap-aka-prime"
+	CryptoProtocolTypePRINS       CryptoProtocolType = "prins"
+	CryptoProtocolType5GAKA       CryptoProtocolType = "5g-aka"
+	CryptoProtocolTypeOther       CryptoProtocolType = "other"
+	CryptoProtocolTypeUnknown     CryptoProtocolType = "unknown"
 )
 
 type IKEv2TransformTypes struct {
-	Encr  *[]BOMReference `json:"encr,omitempty" xml:"encr,omitempty"`
-	PRF   *[]BOMReference `json:"prf,omitempty" xml:"prf,omitempty"`
-	Integ *[]BOMReference `json:"integ,omitempty" xml:"integ,omitempty"`
-	KE    *[]BOMReference `json:"ke,omitempty" xml:"ke,omitempty"`
-	ESN   bool            `json:"esn" xml:"esn"`
-	Auth  *[]BOMReference `json:"auth,omitempty" xml:"auth,omitempty"`
+	Encr  *[]IKEv2Enc   `json:"encr,omitempty" xml:"encr,omitempty"`
+	PRF   *[]IKEv2Prf   `json:"prf,omitempty" xml:"prf,omitempty"`
+	Integ *[]IKEv2Integ `json:"integ,omitempty" xml:"integ,omitempty"`
+	KE    *[]IKEv2Ke    `json:"ke,omitempty" xml:"ke,omitempty"`
+	ESN   bool          `json:"esn" xml:"esn"`
+	Auth  *[]IKEv2Auth  `json:"auth,omitempty" xml:"auth,omitempty"`
 }
 
 type SecuredBy struct {
@@ -585,6 +592,15 @@ type DeclarationEvidence struct {
 
 type Definitions struct {
 	Standards *[]StandardDefinition `json:"standards,omitempty" xml:"standards>standard,omitempty"`
+	Patents   *[]PatentChoice       `json:"patents,omitempty" xml:"-"`
+}
+
+// PatentChoice represents either a Patent or a PatentFamily in a definitions patents list.
+// In JSON, the patents array is anyOf[patent, patentFamily]. In XML, the patents element
+// contains a choice sequence of <patent> and <patentFamily> elements.
+type PatentChoice struct {
+	Patent       *Patent       `json:"-" xml:"-"`
+	PatentFamily *PatentFamily `json:"-" xml:"-"`
 }
 
 type EvidenceData struct {
@@ -761,6 +777,10 @@ const (
 	ERTypeVCS                     ExternalReferenceType = "vcs"
 	ERTypeVulnerabilityAssertion  ExternalReferenceType = "vulnerability-assertion"
 	ERTypeWebsite                 ExternalReferenceType = "website"
+	ERTypePatent                  ExternalReferenceType = "patent"
+	ERTypePatentFamily            ExternalReferenceType = "patent-family"
+	ERTypePatentAssertion         ExternalReferenceType = "patent-assertion"
+	ERTypeCitation                ExternalReferenceType = "citation"
 )
 
 type Formula struct {
@@ -920,8 +940,18 @@ const (
 type Licenses []LicenseChoice
 
 type LicenseChoice struct {
-	License    *License `json:"license,omitempty" xml:"-"`
-	Expression string   `json:"expression,omitempty" xml:"-"`
+	License           *License                   `json:"license,omitempty" xml:"-"`
+	Expression        string                     `json:"expression,omitempty" xml:"-"`
+	ExpressionDetails *[]LicenseExpressionDetail `json:"expressionDetails,omitempty" xml:"-"`
+	Acknowledgement   LicenseAcknowledgement     `json:"acknowledgement,omitempty" xml:"-"`
+}
+
+// LicenseExpressionDetail provides details for individual license identifiers within an SPDX expression.
+type LicenseExpressionDetail struct {
+	LicenseIdentifier string        `json:"licenseIdentifier" xml:"-"`
+	BOMRef            string        `json:"bom-ref,omitempty" xml:"-"`
+	Text              *AttachedText `json:"text,omitempty" xml:"-"`
+	URL               string        `json:"url,omitempty" xml:"-"`
 }
 
 type LicenseType string
@@ -1673,6 +1703,25 @@ type Citation struct {
 	Signature    *JSFSignature         `json:"signature,omitempty" xml:"-"`
 }
 
+// PatentLegalStatus represents the legal status of a patent per WIPO ST.27.
+type PatentLegalStatus string
+
+const (
+	PatentLegalStatusPending     PatentLegalStatus = "pending"
+	PatentLegalStatusGranted     PatentLegalStatus = "granted"
+	PatentLegalStatusRevoked     PatentLegalStatus = "revoked"
+	PatentLegalStatusExpired     PatentLegalStatus = "expired"
+	PatentLegalStatusLapsed      PatentLegalStatus = "lapsed"
+	PatentLegalStatusWithdrawn   PatentLegalStatus = "withdrawn"
+	PatentLegalStatusAbandoned   PatentLegalStatus = "abandoned"
+	PatentLegalStatusSuspended   PatentLegalStatus = "suspended"
+	PatentLegalStatusReinstated  PatentLegalStatus = "reinstated"
+	PatentLegalStatusOpposed     PatentLegalStatus = "opposed"
+	PatentLegalStatusTerminated  PatentLegalStatus = "terminated"
+	PatentLegalStatusInvalidated PatentLegalStatus = "invalidated"
+	PatentLegalStatusInForce     PatentLegalStatus = "in-force"
+)
+
 // Patent represents patent information
 type Patent struct {
 	BOMRef               string                  `json:"bom-ref,omitempty" xml:"bom-ref,attr,omitempty"`
@@ -1686,7 +1735,7 @@ type Patent struct {
 	FilingDate           string                  `json:"filingDate,omitempty" xml:"filingDate,omitempty"`
 	GrantDate            string                  `json:"grantDate,omitempty" xml:"grantDate,omitempty"`
 	PatentExpirationDate string                  `json:"patentExpirationDate,omitempty" xml:"patentExpirationDate,omitempty"`
-	PatentLegalStatus    string                  `json:"patentLegalStatus" xml:"patentLegalStatus"`
+	PatentLegalStatus    PatentLegalStatus       `json:"patentLegalStatus" xml:"patentLegalStatus"`
 	PatentAssignee       *[]OrganizationalEntity `json:"patentAssignee,omitempty" xml:"patentAssignee>assignee,omitempty"`
 	ExternalReferences   *[]ExternalReference    `json:"externalReferences,omitempty" xml:"externalReferences>reference,omitempty"`
 }
@@ -1742,7 +1791,7 @@ const (
 	TLPClassificationClear          TLPClassification = "CLEAR"
 	TLPClassificationGreen          TLPClassification = "GREEN"
 	TLPClassificationAmber          TLPClassification = "AMBER"
-	TLPClassificationAmberAndStrict TLPClassification = "AMBER+STRICT"
+	TLPClassificationAmberAndStrict TLPClassification = "AMBER_AND_STRICT"
 	TLPClassificationRed            TLPClassification = "RED"
 )
 
@@ -1755,7 +1804,7 @@ type IKEv2Auth struct {
 // IKEv2Enc represents IKEv2 Encryption algorithm
 type IKEv2Enc struct {
 	Name      string `json:"name,omitempty" xml:"name,omitempty"`
-	KeyLength int    `json:"keyLength,omitempty" xml:"keyLength,omitempty"`
+	KeyLength *int   `json:"keyLength,omitempty" xml:"keyLength,omitempty"`
 	Algorithm string `json:"algorithm,omitempty" xml:"algorithm,omitempty"`
 }
 
@@ -1767,7 +1816,7 @@ type IKEv2Integ struct {
 
 // IKEv2Ke represents IKEv2 Key Exchange method
 type IKEv2Ke struct {
-	Group     int    `json:"group,omitempty" xml:"group,omitempty"`
+	Group     *int   `json:"group,omitempty" xml:"group,omitempty"`
 	Algorithm string `json:"algorithm,omitempty" xml:"algorithm,omitempty"`
 }
 

--- a/cyclonedx_json.go
+++ b/cyclonedx_json.go
@@ -126,6 +126,8 @@ func (sv *SpecVersion) UnmarshalJSON(bytes []byte) error {
 		*sv = SpecVersion1_5
 	case SpecVersion1_6.String():
 		*sv = SpecVersion1_6
+	case SpecVersion1_7.String():
+		*sv = SpecVersion1_7
 	default:
 		return ErrInvalidSpecVersion
 	}
@@ -242,4 +244,5 @@ var jsonSchemas = map[SpecVersion]string{
 	SpecVersion1_4: "http://cyclonedx.org/schema/bom-1.4.schema.json",
 	SpecVersion1_5: "http://cyclonedx.org/schema/bom-1.5.schema.json",
 	SpecVersion1_6: "http://cyclonedx.org/schema/bom-1.6.schema.json",
+	SpecVersion1_7: "http://cyclonedx.org/schema/bom-1.7.schema.json",
 }

--- a/cyclonedx_json.go
+++ b/cyclonedx_json.go
@@ -236,6 +236,17 @@ func (ev *Evidence) UnmarshalJSON(bytes []byte) error {
 	return nil
 }
 
+func (l License) MarshalJSON() ([]byte, error) {
+	if l.ID != "" && l.Name != "" {
+		return nil, fmt.Errorf("license must have either id or name, not both")
+	}
+	if l.ID == "" && l.Name == "" {
+		return nil, fmt.Errorf("license must have either id or name")
+	}
+	type Alias License
+	return json.Marshal(Alias(l))
+}
+
 func (pc PatentChoice) MarshalJSON() ([]byte, error) {
 	if pc.Patent != nil {
 		return json.Marshal(pc.Patent)

--- a/cyclonedx_json.go
+++ b/cyclonedx_json.go
@@ -236,6 +236,43 @@ func (ev *Evidence) UnmarshalJSON(bytes []byte) error {
 	return nil
 }
 
+func (pc PatentChoice) MarshalJSON() ([]byte, error) {
+	if pc.Patent != nil {
+		return json.Marshal(pc.Patent)
+	} else if pc.PatentFamily != nil {
+		return json.Marshal(pc.PatentFamily)
+	}
+
+	return []byte("{}"), nil
+}
+
+func (pc *PatentChoice) UnmarshalJSON(data []byte) error {
+	// Distinguish patent from patentFamily by checking for the familyId field,
+	// which is the required field unique to patentFamily.
+	var peek struct {
+		FamilyID string `json:"familyId"`
+	}
+	if err := json.Unmarshal(data, &peek); err != nil {
+		return err
+	}
+
+	if peek.FamilyID != "" {
+		var pf PatentFamily
+		if err := json.Unmarshal(data, &pf); err != nil {
+			return err
+		}
+		pc.PatentFamily = &pf
+		return nil
+	}
+
+	var p Patent
+	if err := json.Unmarshal(data, &p); err != nil {
+		return err
+	}
+	pc.Patent = &p
+	return nil
+}
+
 var jsonSchemas = map[SpecVersion]string{
 	SpecVersion1_0: "",
 	SpecVersion1_1: "",

--- a/cyclonedx_json.go
+++ b/cyclonedx_json.go
@@ -300,6 +300,118 @@ func (ce *CertificateExtension) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (ac AsserterChoice) MarshalJSON() ([]byte, error) {
+	if ac.Organization != nil {
+		return json.Marshal(struct {
+			Organization *OrganizationalEntity `json:"organization"`
+		}{Organization: ac.Organization})
+	} else if ac.Individual != nil {
+		return json.Marshal(struct {
+			Individual *OrganizationalContact `json:"individual"`
+		}{Individual: ac.Individual})
+	} else if ac.BOMRef != nil {
+		return json.Marshal(struct {
+			BOMRef *BOMReference `json:"ref"`
+		}{BOMRef: ac.BOMRef})
+	}
+	return []byte("{}"), nil
+}
+
+func (ac *AsserterChoice) UnmarshalJSON(data []byte) error {
+	var peek struct {
+		Organization *json.RawMessage `json:"organization"`
+		Individual   *json.RawMessage `json:"individual"`
+		BOMRef       *json.RawMessage `json:"ref"`
+	}
+	if err := json.Unmarshal(data, &peek); err != nil {
+		return err
+	}
+	if peek.Organization != nil {
+		var org OrganizationalEntity
+		if err := json.Unmarshal(*peek.Organization, &org); err != nil {
+			return err
+		}
+		ac.Organization = &org
+	} else if peek.Individual != nil {
+		var contact OrganizationalContact
+		if err := json.Unmarshal(*peek.Individual, &contact); err != nil {
+			return err
+		}
+		ac.Individual = &contact
+	} else if peek.BOMRef != nil {
+		var ref BOMReference
+		if err := json.Unmarshal(*peek.BOMRef, &ref); err != nil {
+			return err
+		}
+		ac.BOMRef = &ref
+	}
+	return nil
+}
+
+func ikev2MarshalJSON(bomRef BOMReference, structured interface{}) ([]byte, error) {
+	if bomRef != "" {
+		return json.Marshal(string(bomRef))
+	}
+	return json.Marshal(structured)
+}
+
+func ikev2UnmarshalJSON(data []byte, bomRef *BOMReference, structured interface{}) error {
+	if len(data) > 0 && data[0] == '"' {
+		return json.Unmarshal(data, bomRef)
+	}
+	return json.Unmarshal(data, structured)
+}
+
+func (v IKEv2Auth) MarshalJSON() ([]byte, error) {
+	type alias IKEv2Auth
+	return ikev2MarshalJSON(v.BOMRef, alias(v))
+}
+
+func (v *IKEv2Auth) UnmarshalJSON(data []byte) error {
+	type alias IKEv2Auth
+	return ikev2UnmarshalJSON(data, &v.BOMRef, (*alias)(v))
+}
+
+func (v IKEv2Enc) MarshalJSON() ([]byte, error) {
+	type alias IKEv2Enc
+	return ikev2MarshalJSON(v.BOMRef, alias(v))
+}
+
+func (v *IKEv2Enc) UnmarshalJSON(data []byte) error {
+	type alias IKEv2Enc
+	return ikev2UnmarshalJSON(data, &v.BOMRef, (*alias)(v))
+}
+
+func (v IKEv2Integ) MarshalJSON() ([]byte, error) {
+	type alias IKEv2Integ
+	return ikev2MarshalJSON(v.BOMRef, alias(v))
+}
+
+func (v *IKEv2Integ) UnmarshalJSON(data []byte) error {
+	type alias IKEv2Integ
+	return ikev2UnmarshalJSON(data, &v.BOMRef, (*alias)(v))
+}
+
+func (v IKEv2Ke) MarshalJSON() ([]byte, error) {
+	type alias IKEv2Ke
+	return ikev2MarshalJSON(v.BOMRef, alias(v))
+}
+
+func (v *IKEv2Ke) UnmarshalJSON(data []byte) error {
+	type alias IKEv2Ke
+	return ikev2UnmarshalJSON(data, &v.BOMRef, (*alias)(v))
+}
+
+func (v IKEv2Prf) MarshalJSON() ([]byte, error) {
+	type alias IKEv2Prf
+	return ikev2MarshalJSON(v.BOMRef, alias(v))
+}
+
+func (v *IKEv2Prf) UnmarshalJSON(data []byte) error {
+	type alias IKEv2Prf
+	return ikev2UnmarshalJSON(data, &v.BOMRef, (*alias)(v))
+}
+
 func (pc PatentChoice) MarshalJSON() ([]byte, error) {
 	if pc.Patent != nil {
 		return json.Marshal(pc.Patent)

--- a/cyclonedx_json.go
+++ b/cyclonedx_json.go
@@ -247,6 +247,76 @@ func (l License) MarshalJSON() ([]byte, error) {
 	return json.Marshal(Alias(l))
 }
 
+func (cs CertificateState) MarshalJSON() ([]byte, error) {
+	if cs.Predefined != nil && cs.Custom != nil {
+		return nil, fmt.Errorf("either a predefined or custom certificate state can be used, but not both")
+	}
+	if cs.Predefined != nil {
+		return json.Marshal(cs.Predefined)
+	} else if cs.Custom != nil {
+		return json.Marshal(cs.Custom)
+	}
+	return []byte("{}"), nil
+}
+
+func (cs *CertificateState) UnmarshalJSON(data []byte) error {
+	var peek struct {
+		State string `json:"state"`
+	}
+	if err := json.Unmarshal(data, &peek); err != nil {
+		return err
+	}
+	if peek.State != "" {
+		var p PredefinedCertificateState
+		if err := json.Unmarshal(data, &p); err != nil {
+			return err
+		}
+		cs.Predefined = &p
+		return nil
+	}
+	var c CustomCertificateState
+	if err := json.Unmarshal(data, &c); err != nil {
+		return err
+	}
+	cs.Custom = &c
+	return nil
+}
+
+func (ce CertificateExtension) MarshalJSON() ([]byte, error) {
+	if ce.Common != nil && ce.Custom != nil {
+		return nil, fmt.Errorf("either a common or custom certificate extension can be used, but not both")
+	}
+	if ce.Common != nil {
+		return json.Marshal(ce.Common)
+	} else if ce.Custom != nil {
+		return json.Marshal(ce.Custom)
+	}
+	return []byte("{}"), nil
+}
+
+func (ce *CertificateExtension) UnmarshalJSON(data []byte) error {
+	var peek struct {
+		CommonExtensionName string `json:"commonExtensionName"`
+	}
+	if err := json.Unmarshal(data, &peek); err != nil {
+		return err
+	}
+	if peek.CommonExtensionName != "" {
+		var c CommonCertificateExtension
+		if err := json.Unmarshal(data, &c); err != nil {
+			return err
+		}
+		ce.Common = &c
+		return nil
+	}
+	var c CustomCertificateExtension
+	if err := json.Unmarshal(data, &c); err != nil {
+		return err
+	}
+	ce.Custom = &c
+	return nil
+}
+
 func (pc PatentChoice) MarshalJSON() ([]byte, error) {
 	if pc.Patent != nil {
 		return json.Marshal(pc.Patent)

--- a/cyclonedx_json.go
+++ b/cyclonedx_json.go
@@ -189,50 +189,33 @@ func (tc *ToolsChoice) UnmarshalJSON(bytes []byte) error {
 	return nil
 }
 
-func (ev *Evidence) UnmarshalJSON(bytes []byte) error {
-	type Alias Evidence
-	var aux = &struct {
-		Identity json.RawMessage `json:"identity"`
-		*Alias
-	}{
-		Alias: (*Alias)(ev),
+func (eic EvidenceIdentityChoice) MarshalJSON() ([]byte, error) {
+	if eic.Identity != nil && eic.Identities != nil {
+		return nil, fmt.Errorf("either a single identity or an array of identities can be used, but not both")
 	}
+	if eic.Identity != nil {
+		return json.Marshal(eic.Identity)
+	} else if eic.Identities != nil {
+		return json.Marshal(eic.Identities)
+	}
+	return []byte("null"), nil
+}
 
-	if err := json.Unmarshal(bytes, &aux); err != nil {
+func (eic *EvidenceIdentityChoice) UnmarshalJSON(data []byte) error {
+	// Discriminate based on whether data is an array or a single object.
+	if len(data) > 0 && data[0] == '[' {
+		var identities []EvidenceIdentity
+		if err := json.Unmarshal(data, &identities); err != nil {
+			return err
+		}
+		eic.Identities = &identities
+		return nil
+	}
+	var identity EvidenceIdentity
+	if err := json.Unmarshal(data, &identity); err != nil {
 		return err
 	}
-
-	// Try to unmarshal Identity field as struct
-	if aux.Identity != nil {
-		var identity EvidenceIdentity
-		err := json.Unmarshal(aux.Identity, &identity)
-		if err != nil {
-			var typeErr *json.UnmarshalTypeError
-			if !errors.As(err, &typeErr) || typeErr.Value != "array" {
-				return err
-			}
-
-			// Try to unmarshal Identity field as array
-			var identities []EvidenceIdentity
-			err = json.Unmarshal(aux.Identity, &identities)
-			if err != nil {
-				return err
-			}
-
-			if len(identities) > 0 {
-				ev.Identity = &identities
-			}
-			return nil
-		}
-
-		// The field is required, so we can check for emptiness using this field.
-		// cf. https://cyclonedx.org/docs/1.6/json/#metadata_component_evidence_identity_oneOf_i0_items_field
-		if identity.Field != "" {
-			ev.Identity = &[]EvidenceIdentity{
-				identity,
-			}
-		}
-	}
+	eic.Identity = &identity
 	return nil
 }
 

--- a/cyclonedx_json_test.go
+++ b/cyclonedx_json_test.go
@@ -196,24 +196,26 @@ func TestEvidence_MarshalJSON(t *testing.T) {
 
 	t.Run("WithIdentify", func(t *testing.T) {
 		evidence := Evidence{
-			Identity: &[]EvidenceIdentity{
-				{
-					Field:      EvidenceIdentityFieldTypePURL,
-					Confidence: toPointer(t, float32(1)),
-					Methods: &[]EvidenceIdentityMethod{
-						{
-							Technique:  "filename",
-							Confidence: toPointer(t, float32(0.1)),
-							Value:      "findbugs-project-3.0.0.jar",
+			Identity: &EvidenceIdentityChoice{
+				Identities: &[]EvidenceIdentity{
+					{
+						Field:      EvidenceIdentityFieldTypePURL,
+						Confidence: toPointer(t, float32(1)),
+						Methods: &[]EvidenceIdentityMethod{
+							{
+								Technique:  "filename",
+								Confidence: toPointer(t, float32(0.1)),
+								Value:      "findbugs-project-3.0.0.jar",
+							},
+							{
+								Technique:  "ast-fingerprint",
+								Confidence: toPointer(t, float32(0.9)),
+								Value:      "61e4bc08251761c3a73b606b9110a65899cb7d44f3b14c81ebc1e67c98e1d9ab",
+							},
 						},
-						{
-							Technique:  "ast-fingerprint",
-							Confidence: toPointer(t, float32(0.9)),
-							Value:      "61e4bc08251761c3a73b606b9110a65899cb7d44f3b14c81ebc1e67c98e1d9ab",
+						Tools: &[]BOMReference{
+							"bom-ref-of-tool-that-performed-analysis",
 						},
-					},
-					Tools: &[]BOMReference{
-						"bom-ref-of-tool-that-performed-analysis",
 					},
 				},
 			},
@@ -281,8 +283,8 @@ func TestEvidence_UnmarshalJSON(t *testing.T) {
   ]
 }}`), &evidence)
 		require.NoError(t, err)
-		require.Equal(t, &[]EvidenceIdentity{
-			{
+		require.Equal(t, &EvidenceIdentityChoice{
+			Identity: &EvidenceIdentity{
 				Field:      EvidenceIdentityFieldTypePURL,
 				Confidence: toPointer(t, float32(1)),
 				Methods: &[]EvidenceIdentityMethod{
@@ -318,14 +320,16 @@ func TestEvidence_UnmarshalJSON(t *testing.T) {
 	}
 ]}`), &evidence)
 		require.NoError(t, err)
-		require.Equal(t, &[]EvidenceIdentity{
-			{
-				Field:      EvidenceIdentityFieldTypePURL,
-				Confidence: toPointer(t, float32(1)),
-			},
-			{
-				Field:      EvidenceIdentityFieldTypeName,
-				Confidence: toPointer(t, float32(0.1)),
+		require.Equal(t, &EvidenceIdentityChoice{
+			Identities: &[]EvidenceIdentity{
+				{
+					Field:      EvidenceIdentityFieldTypePURL,
+					Confidence: toPointer(t, float32(1)),
+				},
+				{
+					Field:      EvidenceIdentityFieldTypeName,
+					Confidence: toPointer(t, float32(0.1)),
+				},
 			},
 		}, evidence.Identity)
 	})

--- a/cyclonedx_string.go
+++ b/cyclonedx_string.go
@@ -18,11 +18,11 @@ const _MediaType_name = "application/vnd.cyclonedx+jsonapplication/vnd.cyclonedx
 var _MediaType_index = [...]uint8{0, 30, 59, 95}
 
 func (i MediaType) String() string {
-	i -= 1
-	if i < 0 || i >= MediaType(len(_MediaType_index)-1) {
-		return "MediaType(" + strconv.FormatInt(int64(i+1), 10) + ")"
+	idx := int(i) - 1
+	if i < 1 || idx >= len(_MediaType_index)-1 {
+		return "MediaType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
-	return _MediaType_name[_MediaType_index[i]:_MediaType_index[i+1]]
+	return _MediaType_name[_MediaType_index[idx]:_MediaType_index[idx+1]]
 }
 func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
@@ -35,16 +35,17 @@ func _() {
 	_ = x[SpecVersion1_4-5]
 	_ = x[SpecVersion1_5-6]
 	_ = x[SpecVersion1_6-7]
+	_ = x[SpecVersion1_7-8]
 }
 
-const _SpecVersion_name = "1.01.11.21.31.41.51.6"
+const _SpecVersion_name = "1.01.11.21.31.41.51.61.7"
 
-var _SpecVersion_index = [...]uint8{0, 3, 6, 9, 12, 15, 18, 21}
+var _SpecVersion_index = [...]uint8{0, 3, 6, 9, 12, 15, 18, 21, 24}
 
 func (i SpecVersion) String() string {
-	i -= 1
-	if i < 0 || i >= SpecVersion(len(_SpecVersion_index)-1) {
-		return "SpecVersion(" + strconv.FormatInt(int64(i+1), 10) + ")"
+	idx := int(i) - 1
+	if i < 1 || idx >= len(_SpecVersion_index)-1 {
+		return "SpecVersion(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
-	return _SpecVersion_name[_SpecVersion_index[i]:_SpecVersion_index[i+1]]
+	return _SpecVersion_name[_SpecVersion_index[idx]:_SpecVersion_index[idx+1]]
 }

--- a/cyclonedx_xml.go
+++ b/cyclonedx_xml.go
@@ -313,6 +313,8 @@ func (sv *SpecVersion) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 		*sv = SpecVersion1_5
 	case SpecVersion1_6.String():
 		*sv = SpecVersion1_6
+	case SpecVersion1_7.String():
+		*sv = SpecVersion1_7
 	default:
 		return ErrInvalidSpecVersion
 	}
@@ -550,4 +552,5 @@ var xmlNamespaces = map[SpecVersion]string{
 	SpecVersion1_4: "http://cyclonedx.org/schema/bom/1.4",
 	SpecVersion1_5: "http://cyclonedx.org/schema/bom/1.5",
 	SpecVersion1_6: "http://cyclonedx.org/schema/bom/1.6",
+	SpecVersion1_7: "http://cyclonedx.org/schema/bom/1.7",
 }

--- a/cyclonedx_xml.go
+++ b/cyclonedx_xml.go
@@ -184,6 +184,28 @@ func (ev *EnvironmentVariables) UnmarshalXML(d *xml.Decoder, _ xml.StartElement)
 	return nil
 }
 
+// licenseExpressionXML is used for marshaling/unmarshaling the simple <expression> XML element
+// which carries the expression text as character data and acknowledgement/bom-ref as attributes.
+type licenseExpressionXML struct {
+	Expression      string `xml:",chardata"`
+	Acknowledgement string `xml:"acknowledgement,attr,omitempty"`
+	BOMRef          string `xml:"bom-ref,attr,omitempty"`
+}
+
+// licenseExpressionDetailedXML is used for marshaling/unmarshaling the <expression-detailed> element.
+type licenseExpressionDetailedXML struct {
+	Expression      string                       `xml:"expression,attr"`
+	Acknowledgement string                       `xml:"acknowledgement,attr,omitempty"`
+	BOMRef          string                       `xml:"bom-ref,attr,omitempty"`
+	Details         []licenseExpressionDetailXML `xml:"details"`
+}
+
+type licenseExpressionDetailXML struct {
+	LicenseIdentifier string        `xml:"license-identifier,attr"`
+	Text              *AttachedText `xml:"text,omitempty"`
+	URL               string        `xml:"url,omitempty"`
+}
+
 func (l Licenses) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	if len(l) == 0 {
 		return nil
@@ -203,8 +225,30 @@ func (l Licenses) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 				return err
 			}
 		} else if choice.Expression != "" {
-			if err := e.EncodeElement(choice.Expression, xml.StartElement{Name: xml.Name{Local: "expression"}}); err != nil {
-				return err
+			if choice.ExpressionDetails != nil {
+				// Use expression-detailed element when expressionDetails are present
+				detailed := licenseExpressionDetailedXML{
+					Expression:      choice.Expression,
+					Acknowledgement: string(choice.Acknowledgement),
+				}
+				for _, d := range *choice.ExpressionDetails {
+					detailed.Details = append(detailed.Details, licenseExpressionDetailXML{
+						LicenseIdentifier: d.LicenseIdentifier,
+						Text:              d.Text,
+						URL:               d.URL,
+					})
+				}
+				if err := e.EncodeElement(detailed, xml.StartElement{Name: xml.Name{Local: "expression-detailed"}}); err != nil {
+					return err
+				}
+			} else {
+				exprXML := licenseExpressionXML{
+					Expression:      choice.Expression,
+					Acknowledgement: string(choice.Acknowledgement),
+				}
+				if err := e.EncodeElement(exprXML, xml.StartElement{Name: xml.Name{Local: "expression"}}); err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -228,11 +272,35 @@ func (l *Licenses) UnmarshalXML(d *xml.Decoder, _ xml.StartElement) error {
 		case xml.StartElement:
 			switch tokenType.Name.Local {
 			case "expression":
-				var expression string
-				if err = d.DecodeElement(&expression, &tokenType); err != nil {
+				var exprXML licenseExpressionXML
+				if err = d.DecodeElement(&exprXML, &tokenType); err != nil {
 					return err
 				}
-				licenses = append(licenses, LicenseChoice{Expression: expression})
+				licenses = append(licenses, LicenseChoice{
+					Expression:      exprXML.Expression,
+					Acknowledgement: LicenseAcknowledgement(exprXML.Acknowledgement),
+				})
+			case "expression-detailed":
+				var detailed licenseExpressionDetailedXML
+				if err = d.DecodeElement(&detailed, &tokenType); err != nil {
+					return err
+				}
+				choice := LicenseChoice{
+					Expression:      detailed.Expression,
+					Acknowledgement: LicenseAcknowledgement(detailed.Acknowledgement),
+				}
+				if len(detailed.Details) > 0 {
+					details := make([]LicenseExpressionDetail, len(detailed.Details))
+					for i, det := range detailed.Details {
+						details[i] = LicenseExpressionDetail{
+							LicenseIdentifier: det.LicenseIdentifier,
+							Text:              det.Text,
+							URL:               det.URL,
+						}
+					}
+					choice.ExpressionDetails = &details
+				}
+				licenses = append(licenses, choice)
 			case "license":
 				var license License
 				if err = d.DecodeElement(&license, &tokenType); err != nil {
@@ -541,6 +609,136 @@ func (ev *Evidence) UnmarshalXML(d *xml.Decoder, _ xml.StartElement) error {
 	}
 
 	*ev = evidence
+	return nil
+}
+
+func (d Definitions) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if err := e.EncodeToken(start); err != nil {
+		return err
+	}
+
+	if d.Standards != nil {
+		standardsStart := xml.StartElement{Name: xml.Name{Local: "standards"}}
+		if err := e.EncodeToken(standardsStart); err != nil {
+			return err
+		}
+		for _, s := range *d.Standards {
+			if err := e.EncodeElement(s, xml.StartElement{Name: xml.Name{Local: "standard"}}); err != nil {
+				return err
+			}
+		}
+		if err := e.EncodeToken(standardsStart.End()); err != nil {
+			return err
+		}
+	}
+
+	if d.Patents != nil {
+		patentsStart := xml.StartElement{Name: xml.Name{Local: "patents"}}
+		if err := e.EncodeToken(patentsStart); err != nil {
+			return err
+		}
+		for _, choice := range *d.Patents {
+			if choice.Patent != nil {
+				if err := e.EncodeElement(choice.Patent, xml.StartElement{Name: xml.Name{Local: "patent"}}); err != nil {
+					return err
+				}
+			} else if choice.PatentFamily != nil {
+				if err := e.EncodeElement(choice.PatentFamily, xml.StartElement{Name: xml.Name{Local: "patentFamily"}}); err != nil {
+					return err
+				}
+			}
+		}
+		if err := e.EncodeToken(patentsStart.End()); err != nil {
+			return err
+		}
+	}
+
+	return e.EncodeToken(start.End())
+}
+
+func (d *Definitions) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	for {
+		token, err := dec.Token()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return err
+		}
+
+		switch t := token.(type) {
+		case xml.StartElement:
+			switch t.Name.Local {
+			case "standards":
+				var standards []StandardDefinition
+				for {
+					innerToken, err := dec.Token()
+					if err != nil {
+						if errors.Is(err, io.EOF) {
+							break
+						}
+						return err
+					}
+					switch it := innerToken.(type) {
+					case xml.StartElement:
+						if it.Name.Local == "standard" {
+							var s StandardDefinition
+							if err = dec.DecodeElement(&s, &it); err != nil {
+								return err
+							}
+							standards = append(standards, s)
+						}
+					case xml.EndElement:
+						goto doneStandards
+					}
+				}
+			doneStandards:
+				if len(standards) > 0 {
+					d.Standards = &standards
+				}
+			case "patents":
+				var choices []PatentChoice
+				for {
+					innerToken, err := dec.Token()
+					if err != nil {
+						if errors.Is(err, io.EOF) {
+							break
+						}
+						return err
+					}
+					switch it := innerToken.(type) {
+					case xml.StartElement:
+						switch it.Name.Local {
+						case "patent":
+							var p Patent
+							if err = dec.DecodeElement(&p, &it); err != nil {
+								return err
+							}
+							choices = append(choices, PatentChoice{Patent: &p})
+						case "patentFamily":
+							var pf PatentFamily
+							if err = dec.DecodeElement(&pf, &it); err != nil {
+								return err
+							}
+							choices = append(choices, PatentChoice{PatentFamily: &pf})
+						}
+					case xml.EndElement:
+						goto donePatents
+					}
+				}
+			donePatents:
+				if len(choices) > 0 {
+					d.Patents = &choices
+				}
+			default:
+				if err = dec.Skip(); err != nil {
+					return err
+				}
+			}
+		case xml.EndElement:
+			return nil
+		}
+	}
 	return nil
 }
 

--- a/cyclonedx_xml.go
+++ b/cyclonedx_xml.go
@@ -184,6 +184,17 @@ func (ev *EnvironmentVariables) UnmarshalXML(d *xml.Decoder, _ xml.StartElement)
 	return nil
 }
 
+func (l License) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if l.ID != "" && l.Name != "" {
+		return fmt.Errorf("license must have either id or name, not both")
+	}
+	if l.ID == "" && l.Name == "" {
+		return fmt.Errorf("license must have either id or name")
+	}
+	type Alias License
+	return e.EncodeElement(Alias(l), start)
+}
+
 // licenseExpressionXML is used for marshaling/unmarshaling the simple <expression> XML element
 // which carries the expression text as character data and acknowledgement/bom-ref as attributes.
 type licenseExpressionXML struct {
@@ -225,11 +236,16 @@ func (l Licenses) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 				return err
 			}
 		} else if choice.Expression != "" {
+			var ackStr string
+			if choice.Acknowledgement != nil {
+				ackStr = string(*choice.Acknowledgement)
+			}
 			if choice.ExpressionDetails != nil {
 				// Use expression-detailed element when expressionDetails are present
 				detailed := licenseExpressionDetailedXML{
 					Expression:      choice.Expression,
-					Acknowledgement: string(choice.Acknowledgement),
+					Acknowledgement: ackStr,
+					BOMRef:          choice.BOMRef,
 				}
 				for _, d := range *choice.ExpressionDetails {
 					detailed.Details = append(detailed.Details, licenseExpressionDetailXML{
@@ -244,7 +260,8 @@ func (l Licenses) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 			} else {
 				exprXML := licenseExpressionXML{
 					Expression:      choice.Expression,
-					Acknowledgement: string(choice.Acknowledgement),
+					Acknowledgement: ackStr,
+					BOMRef:          choice.BOMRef,
 				}
 				if err := e.EncodeElement(exprXML, xml.StartElement{Name: xml.Name{Local: "expression"}}); err != nil {
 					return err
@@ -276,18 +293,27 @@ func (l *Licenses) UnmarshalXML(d *xml.Decoder, _ xml.StartElement) error {
 				if err = d.DecodeElement(&exprXML, &tokenType); err != nil {
 					return err
 				}
-				licenses = append(licenses, LicenseChoice{
-					Expression:      exprXML.Expression,
-					Acknowledgement: LicenseAcknowledgement(exprXML.Acknowledgement),
-				})
+				choice := LicenseChoice{
+					Expression: exprXML.Expression,
+					BOMRef:     exprXML.BOMRef,
+				}
+				if exprXML.Acknowledgement != "" {
+					ack := LicenseAcknowledgement(exprXML.Acknowledgement)
+					choice.Acknowledgement = &ack
+				}
+				licenses = append(licenses, choice)
 			case "expression-detailed":
 				var detailed licenseExpressionDetailedXML
 				if err = d.DecodeElement(&detailed, &tokenType); err != nil {
 					return err
 				}
 				choice := LicenseChoice{
-					Expression:      detailed.Expression,
-					Acknowledgement: LicenseAcknowledgement(detailed.Acknowledgement),
+					Expression: detailed.Expression,
+					BOMRef:     detailed.BOMRef,
+				}
+				if detailed.Acknowledgement != "" {
+					ack := LicenseAcknowledgement(detailed.Acknowledgement)
+					choice.Acknowledgement = &ack
 				}
 				if len(detailed.Details) > 0 {
 					details := make([]LicenseExpressionDetail, len(detailed.Details))

--- a/cyclonedx_xml.go
+++ b/cyclonedx_xml.go
@@ -416,6 +416,115 @@ func (sv *SpecVersion) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 	return nil
 }
 
+type predefinedCertificateStateXML struct {
+	State  CertificateStateType `xml:"state"`
+	Reason string               `xml:"reason,omitempty"`
+}
+
+type customCertificateStateXML struct {
+	Name        string `xml:"name"`
+	Description string `xml:"description,omitempty"`
+	Reason      string `xml:"reason,omitempty"`
+}
+
+func (cs CertificateState) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if cs.Predefined != nil && cs.Custom != nil {
+		return fmt.Errorf("either a predefined or custom certificate state can be used, but not both")
+	}
+	if cs.Predefined != nil {
+		return e.EncodeElement(predefinedCertificateStateXML{
+			State:  cs.Predefined.State,
+			Reason: cs.Predefined.Reason,
+		}, start)
+	}
+	if cs.Custom != nil {
+		return e.EncodeElement(customCertificateStateXML{
+			Name:        cs.Custom.Name,
+			Description: cs.Custom.Description,
+			Reason:      cs.Custom.Reason,
+		}, start)
+	}
+	return nil
+}
+
+func (cs *CertificateState) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var raw struct {
+		State       string `xml:"state"`
+		Name        string `xml:"name"`
+		Description string `xml:"description"`
+		Reason      string `xml:"reason"`
+	}
+	if err := d.DecodeElement(&raw, &start); err != nil {
+		return err
+	}
+	if raw.State != "" {
+		cs.Predefined = &PredefinedCertificateState{
+			State:  CertificateStateType(raw.State),
+			Reason: raw.Reason,
+		}
+	} else {
+		cs.Custom = &CustomCertificateState{
+			Name:        raw.Name,
+			Description: raw.Description,
+			Reason:      raw.Reason,
+		}
+	}
+	return nil
+}
+
+type commonCertificateExtensionXML struct {
+	Name  CertificateExtensionName `xml:"commonExtensionName"`
+	Value string                   `xml:"commonExtensionValue,omitempty"`
+}
+
+type customCertificateExtensionXML struct {
+	Name  string `xml:"customExtensionName"`
+	Value string `xml:"customExtensionValue,omitempty"`
+}
+
+func (ce CertificateExtension) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if ce.Common != nil && ce.Custom != nil {
+		return fmt.Errorf("either a common or custom certificate extension can be used, but not both")
+	}
+	if ce.Common != nil {
+		return e.EncodeElement(commonCertificateExtensionXML{
+			Name:  ce.Common.Name,
+			Value: ce.Common.Value,
+		}, start)
+	}
+	if ce.Custom != nil {
+		return e.EncodeElement(customCertificateExtensionXML{
+			Name:  ce.Custom.Name,
+			Value: ce.Custom.Value,
+		}, start)
+	}
+	return nil
+}
+
+func (ce *CertificateExtension) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var raw struct {
+		CommonExtensionName  string `xml:"commonExtensionName"`
+		CommonExtensionValue string `xml:"commonExtensionValue"`
+		CustomExtensionName  string `xml:"customExtensionName"`
+		CustomExtensionValue string `xml:"customExtensionValue"`
+	}
+	if err := d.DecodeElement(&raw, &start); err != nil {
+		return err
+	}
+	if raw.CommonExtensionName != "" {
+		ce.Common = &CommonCertificateExtension{
+			Name:  CertificateExtensionName(raw.CommonExtensionName),
+			Value: raw.CommonExtensionValue,
+		}
+	} else {
+		ce.Custom = &CustomCertificateExtension{
+			Name:  raw.CustomExtensionName,
+			Value: raw.CustomExtensionValue,
+		}
+	}
+	return nil
+}
+
 // toolsChoiceMarshalXML is a helper struct for marshalling ToolsChoice.
 type toolsChoiceMarshalXML struct {
 	LegacyTools *[]Tool      `json:"-" xml:"tool,omitempty"`

--- a/cyclonedx_xml.go
+++ b/cyclonedx_xml.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 )
 
 // bomReferenceXML is temporarily used for marshalling and unmarshalling
@@ -521,6 +522,205 @@ func (ce *CertificateExtension) UnmarshalXML(d *xml.Decoder, start xml.StartElem
 			Name:  raw.CustomExtensionName,
 			Value: raw.CustomExtensionValue,
 		}
+	}
+	return nil
+}
+
+func (ac AsserterChoice) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if ac.Organization != nil && ac.Individual != nil {
+		return fmt.Errorf("asserter can only be one of organization, individual, or ref")
+	}
+	if ac.Organization != nil {
+		return e.EncodeElement(struct {
+			Organization *OrganizationalEntity `xml:"organization"`
+		}{Organization: ac.Organization}, start)
+	}
+	if ac.Individual != nil {
+		return e.EncodeElement(struct {
+			Individual *OrganizationalContact `xml:"contact"`
+		}{Individual: ac.Individual}, start)
+	}
+	if ac.BOMRef != nil {
+		return e.EncodeElement(struct {
+			BOMRef *BOMReference `xml:"ref"`
+		}{BOMRef: ac.BOMRef}, start)
+	}
+	return nil
+}
+
+func (ac *AsserterChoice) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var raw struct {
+		Organization *OrganizationalEntity  `xml:"organization"`
+		Individual   *OrganizationalContact `xml:"contact"`
+		BOMRef       *BOMReference          `xml:"ref"`
+	}
+	if err := d.DecodeElement(&raw, &start); err != nil {
+		return err
+	}
+	ac.Organization = raw.Organization
+	ac.Individual = raw.Individual
+	ac.BOMRef = raw.BOMRef
+	return nil
+}
+
+func (v IKEv2Auth) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type alias IKEv2Auth
+	if v.BOMRef != "" {
+		if err := e.EncodeToken(start); err != nil {
+			return err
+		}
+		if err := e.EncodeToken(xml.CharData(string(v.BOMRef))); err != nil {
+			return err
+		}
+		return e.EncodeToken(start.End())
+	}
+	return e.EncodeElement(alias(v), start)
+}
+
+func (v *IKEv2Auth) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var raw struct {
+		Content   string `xml:",chardata"`
+		Name      string `xml:"name"`
+		Algorithm string `xml:"algorithm"`
+	}
+	if err := d.DecodeElement(&raw, &start); err != nil {
+		return err
+	}
+	if content := strings.TrimSpace(raw.Content); content != "" && raw.Name == "" && raw.Algorithm == "" {
+		v.BOMRef = BOMReference(content)
+	} else {
+		v.Name = raw.Name
+		v.Algorithm = raw.Algorithm
+	}
+	return nil
+}
+
+func (v IKEv2Enc) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type alias IKEv2Enc
+	if v.BOMRef != "" {
+		if err := e.EncodeToken(start); err != nil {
+			return err
+		}
+		if err := e.EncodeToken(xml.CharData(string(v.BOMRef))); err != nil {
+			return err
+		}
+		return e.EncodeToken(start.End())
+	}
+	return e.EncodeElement(alias(v), start)
+}
+
+func (v *IKEv2Enc) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var raw struct {
+		Content   string `xml:",chardata"`
+		Name      string `xml:"name"`
+		KeyLength *int   `xml:"keyLength"`
+		Algorithm string `xml:"algorithm"`
+	}
+	if err := d.DecodeElement(&raw, &start); err != nil {
+		return err
+	}
+	if content := strings.TrimSpace(raw.Content); content != "" && raw.Name == "" && raw.Algorithm == "" && raw.KeyLength == nil {
+		v.BOMRef = BOMReference(content)
+	} else {
+		v.Name = raw.Name
+		v.KeyLength = raw.KeyLength
+		v.Algorithm = raw.Algorithm
+	}
+	return nil
+}
+
+func (v IKEv2Integ) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type alias IKEv2Integ
+	if v.BOMRef != "" {
+		if err := e.EncodeToken(start); err != nil {
+			return err
+		}
+		if err := e.EncodeToken(xml.CharData(string(v.BOMRef))); err != nil {
+			return err
+		}
+		return e.EncodeToken(start.End())
+	}
+	return e.EncodeElement(alias(v), start)
+}
+
+func (v *IKEv2Integ) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var raw struct {
+		Content   string `xml:",chardata"`
+		Name      string `xml:"name"`
+		Algorithm string `xml:"algorithm"`
+	}
+	if err := d.DecodeElement(&raw, &start); err != nil {
+		return err
+	}
+	if content := strings.TrimSpace(raw.Content); content != "" && raw.Name == "" && raw.Algorithm == "" {
+		v.BOMRef = BOMReference(content)
+	} else {
+		v.Name = raw.Name
+		v.Algorithm = raw.Algorithm
+	}
+	return nil
+}
+
+func (v IKEv2Ke) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type alias IKEv2Ke
+	if v.BOMRef != "" {
+		if err := e.EncodeToken(start); err != nil {
+			return err
+		}
+		if err := e.EncodeToken(xml.CharData(string(v.BOMRef))); err != nil {
+			return err
+		}
+		return e.EncodeToken(start.End())
+	}
+	return e.EncodeElement(alias(v), start)
+}
+
+func (v *IKEv2Ke) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var raw struct {
+		Content   string `xml:",chardata"`
+		Group     *int   `xml:"group"`
+		Algorithm string `xml:"algorithm"`
+	}
+	if err := d.DecodeElement(&raw, &start); err != nil {
+		return err
+	}
+	if content := strings.TrimSpace(raw.Content); content != "" && raw.Algorithm == "" && raw.Group == nil {
+		v.BOMRef = BOMReference(content)
+	} else {
+		v.Group = raw.Group
+		v.Algorithm = raw.Algorithm
+	}
+	return nil
+}
+
+func (v IKEv2Prf) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type alias IKEv2Prf
+	if v.BOMRef != "" {
+		if err := e.EncodeToken(start); err != nil {
+			return err
+		}
+		if err := e.EncodeToken(xml.CharData(string(v.BOMRef))); err != nil {
+			return err
+		}
+		return e.EncodeToken(start.End())
+	}
+	return e.EncodeElement(alias(v), start)
+}
+
+func (v *IKEv2Prf) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var raw struct {
+		Content   string `xml:",chardata"`
+		Name      string `xml:"name"`
+		Algorithm string `xml:"algorithm"`
+	}
+	if err := d.DecodeElement(&raw, &start); err != nil {
+		return err
+	}
+	if content := strings.TrimSpace(raw.Content); content != "" && raw.Name == "" && raw.Algorithm == "" {
+		v.BOMRef = BOMReference(content)
+	} else {
+		v.Name = raw.Name
+		v.Algorithm = raw.Algorithm
 	}
 	return nil
 }

--- a/cyclonedx_xml.go
+++ b/cyclonedx_xml.go
@@ -652,7 +652,11 @@ func (ev Evidence) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	evidenceXML := EvidenceMarshalXML{}
 	empty := true
 	if ev.Identity != nil {
-		evidenceXML.Identity = ev.Identity
+		if ev.Identity.Identities != nil {
+			evidenceXML.Identity = ev.Identity.Identities
+		} else if ev.Identity.Identity != nil {
+			evidenceXML.Identity = &[]EvidenceIdentity{*ev.Identity.Identity}
+		}
 		empty = false
 	}
 	if ev.Occurrences != nil {
@@ -740,7 +744,7 @@ func (ev *Evidence) UnmarshalXML(d *xml.Decoder, _ xml.StartElement) error {
 	}
 
 	if len(identifies) > 0 {
-		evidence.Identity = &identifies
+		evidence.Identity = &EvidenceIdentityChoice{Identities: &identifies}
 	}
 
 	*ev = evidence

--- a/cyclonedx_xml_test.go
+++ b/cyclonedx_xml_test.go
@@ -465,24 +465,26 @@ func TestEvidence_MarshalXML(t *testing.T) {
 
 	t.Run("WithIdentify", func(t *testing.T) {
 		evidence := Evidence{
-			Identity: &[]EvidenceIdentity{
-				{
-					Field:      EvidenceIdentityFieldTypePURL,
-					Confidence: toPointer(t, float32(1)),
-					Methods: &[]EvidenceIdentityMethod{
-						{
-							Technique:  "filename",
-							Confidence: toPointer(t, float32(0.1)),
-							Value:      "findbugs-project-3.0.0.jar",
+			Identity: &EvidenceIdentityChoice{
+				Identities: &[]EvidenceIdentity{
+					{
+						Field:      EvidenceIdentityFieldTypePURL,
+						Confidence: toPointer(t, float32(1)),
+						Methods: &[]EvidenceIdentityMethod{
+							{
+								Technique:  "filename",
+								Confidence: toPointer(t, float32(0.1)),
+								Value:      "findbugs-project-3.0.0.jar",
+							},
+							{
+								Technique:  "ast-fingerprint",
+								Confidence: toPointer(t, float32(0.9)),
+								Value:      "61e4bc08251761c3a73b606b9110a65899cb7d44f3b14c81ebc1e67c98e1d9ab",
+							},
 						},
-						{
-							Technique:  "ast-fingerprint",
-							Confidence: toPointer(t, float32(0.9)),
-							Value:      "61e4bc08251761c3a73b606b9110a65899cb7d44f3b14c81ebc1e67c98e1d9ab",
+						Tools: &[]BOMReference{
+							"bom-ref-of-tool-that-performed-analysis",
 						},
-					},
-					Tools: &[]BOMReference{
-						"bom-ref-of-tool-that-performed-analysis",
 					},
 				},
 			},
@@ -657,24 +659,26 @@ func TestEvidence_UnmarshalXML(t *testing.T) {
 	</identity>
 </evidence>`), &evidence)
 		require.NoError(t, err)
-		require.Equal(t, &[]EvidenceIdentity{
-			{
-				Field:      EvidenceIdentityFieldTypePURL,
-				Confidence: toPointer(t, float32(1)),
-				Methods: &[]EvidenceIdentityMethod{
-					{
-						Technique:  "filename",
-						Confidence: toPointer(t, float32(0.1)),
-						Value:      "findbugs-project-3.0.0.jar",
+		require.Equal(t, &EvidenceIdentityChoice{
+			Identities: &[]EvidenceIdentity{
+				{
+					Field:      EvidenceIdentityFieldTypePURL,
+					Confidence: toPointer(t, float32(1)),
+					Methods: &[]EvidenceIdentityMethod{
+						{
+							Technique:  "filename",
+							Confidence: toPointer(t, float32(0.1)),
+							Value:      "findbugs-project-3.0.0.jar",
+						},
+						{
+							Technique:  "ast-fingerprint",
+							Confidence: toPointer(t, float32(0.9)),
+							Value:      "61e4bc08251761c3a73b606b9110a65899cb7d44f3b14c81ebc1e67c98e1d9ab",
+						},
 					},
-					{
-						Technique:  "ast-fingerprint",
-						Confidence: toPointer(t, float32(0.9)),
-						Value:      "61e4bc08251761c3a73b606b9110a65899cb7d44f3b14c81ebc1e67c98e1d9ab",
+					Tools: &[]BOMReference{
+						"bom-ref-of-tool-that-performed-analysis",
 					},
-				},
-				Tools: &[]BOMReference{
-					"bom-ref-of-tool-that-performed-analysis",
 				},
 			},
 		}, evidence.Identity)
@@ -694,14 +698,16 @@ func TestEvidence_UnmarshalXML(t *testing.T) {
 	</identity>
 </evidence>`), &evidence)
 		require.NoError(t, err)
-		require.Equal(t, &[]EvidenceIdentity{
-			{
-				Field:      EvidenceIdentityFieldTypePURL,
-				Confidence: toPointer(t, float32(1)),
-			},
-			{
-				Field:      EvidenceIdentityFieldTypeName,
-				Confidence: toPointer(t, float32(0.1)),
+		require.Equal(t, &EvidenceIdentityChoice{
+			Identities: &[]EvidenceIdentity{
+				{
+					Field:      EvidenceIdentityFieldTypePURL,
+					Confidence: toPointer(t, float32(1)),
+				},
+				{
+					Field:      EvidenceIdentityFieldTypeName,
+					Confidence: toPointer(t, float32(0.1)),
+				},
 			},
 		}, evidence.Identity)
 	})

--- a/encode_test.go
+++ b/encode_test.go
@@ -50,9 +50,9 @@ func TestJsonBOMEncoder_SetPretty(t *testing.T) {
 	require.NoError(t, encoder.Encode(bom))
 
 	assert.Equal(t, `{
-  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "$schema": "http://cyclonedx.org/schema/bom-1.7.schema.json",
   "bomFormat": "CycloneDX",
-  "specVersion": "1.6",
+  "specVersion": "1.7",
   "version": 1,
   "metadata": {
     "authors": [
@@ -83,9 +83,9 @@ func TestJsonBOMEncoder_SetEscapeHTML_true(t *testing.T) {
 	require.NoError(t, encoder.Encode(bom))
 
 	assert.Equal(t, `{
-  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "$schema": "http://cyclonedx.org/schema/bom-1.7.schema.json",
   "bomFormat": "CycloneDX",
-  "specVersion": "1.6",
+  "specVersion": "1.7",
   "version": 1,
   "metadata": {
     "authors": [
@@ -116,9 +116,9 @@ func TestJsonBOMEncoder_SetEscapeHTML_false(t *testing.T) {
 	require.NoError(t, encoder.Encode(bom))
 
 	assert.Equal(t, `{
-  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "$schema": "http://cyclonedx.org/schema/bom-1.7.schema.json",
   "bomFormat": "CycloneDX",
-  "specVersion": "1.6",
+  "specVersion": "1.7",
   "version": 1,
   "metadata": {
     "authors": [
@@ -158,7 +158,7 @@ func TestXmlBOMEncoder_SetPretty(t *testing.T) {
 	require.NoError(t, encoder.Encode(bom))
 
 	assert.Equal(t, `<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.7" version="1">
   <metadata>
     <authors>
       <author>

--- a/example_test.go
+++ b/example_test.go
@@ -89,7 +89,7 @@ func Example_encode() {
 
 	// Output:
 	// <?xml version="1.0" encoding="UTF-8"?>
-	// <bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+	// <bom xmlns="http://cyclonedx.org/schema/bom/1.7" version="1">
 	//   <metadata>
 	//     <component bom-ref="pkg:golang/acme-inc/acme-app@v1.0.0" type="application">
 	//       <name>ACME Application</name>

--- a/schema/bom-1.7.schema.json
+++ b/schema/bom-1.7.schema.json
@@ -1,0 +1,6700 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://cyclonedx.org/schema/bom-1.7.schema.json",
+  "type": "object",
+  "title": "CycloneDX Bill of Materials Standard",
+  "$comment" : "CycloneDX JSON schema is published under the terms of the Apache License 2.0.",
+  "required": [
+    "bomFormat",
+    "specVersion"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "bomFormat": {
+      "type": "string",
+      "title": "BOM Format",
+      "description": "Specifies the format of the BOM. This helps to identify the file as CycloneDX since BOMs do not have a filename convention, nor does JSON schema support namespaces. This value must be \"CycloneDX\".",
+      "enum": [
+        "CycloneDX"
+      ]
+    },
+    "specVersion": {
+      "type": "string",
+      "title": "CycloneDX Specification Version",
+      "description": "The version of the CycloneDX specification the BOM conforms to.",
+      "examples": ["1.7"]
+    },
+    "serialNumber": {
+      "type": "string",
+      "title": "BOM Serial Number",
+      "description": "Every BOM generated SHOULD have a unique serial number, even if the contents of the BOM have not changed over time. If specified, the serial number must conform to [RFC 4122](https://www.ietf.org/rfc/rfc4122.html). Use of serial numbers is recommended.",
+      "examples": ["urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79"],
+      "pattern": "^urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    },
+    "version": {
+      "type": "integer",
+      "title": "BOM Version",
+      "description": "Whenever an existing BOM is modified, either manually or through automated processes, the version of the BOM SHOULD be incremented by 1. When a system is presented with multiple BOMs with identical serial numbers, the system SHOULD use the most recent version of the BOM. The default version is '1'.",
+      "minimum": 1,
+      "default": 1,
+      "examples": [1]
+    },
+    "metadata": {
+      "$ref": "#/definitions/metadata",
+      "title": "BOM Metadata",
+      "description": "Provides additional information about a BOM."
+    },
+    "components": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/component"},
+      "uniqueItems": true,
+      "title": "Components",
+      "description": "A list of software and hardware components."
+    },
+    "services": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/service"},
+      "uniqueItems": true,
+      "title": "Services",
+      "description": "A list of services. This may include microservices, function-as-a-service, and other types of network or intra-process services."
+    },
+    "externalReferences": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/externalReference"},
+      "title": "External References",
+      "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+    },
+    "dependencies": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/dependency"},
+      "uniqueItems": true,
+      "title": "Dependencies",
+      "description": "Provides the ability to document dependency relationships including provided & implemented components."
+    },
+    "compositions": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/compositions"},
+      "uniqueItems": true,
+      "title": "Compositions",
+      "description": "Compositions describe constituent parts (including components, services, and dependency relationships) and their completeness. The completeness of vulnerabilities expressed in a BOM may also be described."
+    },
+    "vulnerabilities": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/vulnerability"},
+      "uniqueItems": true,
+      "title": "Vulnerabilities",
+      "description": "Vulnerabilities identified in components or services."
+    },
+    "annotations": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/annotations"},
+      "uniqueItems": true,
+      "title": "Annotations",
+      "description": "Comments made by people, organizations, or tools about any object with a bom-ref, such as components, services, vulnerabilities, or the BOM itself. Unlike inventory information, annotations may contain opinions or commentary from various stakeholders. Annotations may be inline (with inventory) or externalized via BOM-Link and may optionally be signed."
+    },
+    "formulation": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/formula"},
+      "uniqueItems": true,
+      "title": "Formulation",
+      "description": "Describes the formulation of any referencable object within the BOM, including components, services, metadata, declarations, or the BOM itself. This may encompass how the object was created, assembled, deployed, tested, certified, or otherwise brought into its present form. Common examples include software build pipelines, deployment processes, AI/ML model training, cryptographic key generation or certification, and third-party audits. Processes are modeled using declared and observed formulas, composed of workflows, tasks, and individual steps."
+    },
+    "declarations": {
+      "type": "object",
+      "title": "Declarations",
+      "description": "The list of declarations which describe the conformance to standards. Each declaration may include attestations, claims, and evidence.",
+      "additionalProperties": false,
+      "properties": {
+        "assessors": {
+          "type": "array",
+          "title": "Assessors",
+          "description": "The list of assessors evaluating claims and determining conformance to requirements and confidence in that assessment.",
+          "items": {
+            "type": "object",
+            "title": "Assessor",
+            "description": "The assessor who evaluates claims and determines conformance to requirements and confidence in that assessment.",
+            "additionalProperties": false,
+            "properties": {
+              "bom-ref": {
+                "$ref": "#/definitions/refType",
+                "title": "BOM Reference",
+                "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
+              },
+              "thirdParty": {
+                "type": "boolean",
+                "title": "Third Party",
+                "description": "The boolean indicating if the assessor is outside the organization generating claims. A value of false indicates a self assessor."
+              },
+              "organization": {
+                "$ref": "#/definitions/organizationalEntity",
+                "title": "Organization",
+                "description": "The entity issuing the assessment."
+              }
+            }
+          }
+        },
+        "attestations": {
+          "type": "array",
+          "title": "Attestations",
+          "description": "The list of attestations asserted by an assessor that maps requirements to claims.",
+          "items": {
+            "type": "object",
+            "title": "Attestation",
+            "additionalProperties": false,
+            "properties": {
+              "summary":  {
+                "type": "string",
+                "title": "Summary",
+                "description": "The short description explaining the main points of the attestation."
+              },
+              "assessor": {
+                "$ref": "#/definitions/refLinkType",
+                "title": "Assessor",
+                "description": "The `bom-ref` to the assessor asserting the attestation."
+              },
+              "map": {
+                "type": "array",
+                "title": "Map",
+                "description": "The grouping of requirements to claims and the attestors declared conformance and confidence thereof.",
+                "items": {
+                  "type": "object",
+                  "title": "Map",
+                  "additionalProperties": false,
+                  "properties": {
+                    "requirement": {
+                      "$ref": "#/definitions/refLinkType",
+                      "title": "Requirement",
+                      "description": "The `bom-ref` to the requirement being attested to."
+                    },
+                    "claims": {
+                      "type": "array",
+                      "title": "Claims",
+                      "description": "The list of `bom-ref` to the claims being attested to.",
+                      "items": { "$ref": "#/definitions/refLinkType" }
+                    },
+                    "counterClaims": {
+                      "type": "array",
+                      "title": "Counter Claims",
+                      "description": "The list of  `bom-ref` to the counter claims being attested to.",
+                      "items": { "$ref": "#/definitions/refLinkType" }
+                    },
+                    "conformance": {
+                      "type": "object",
+                      "title": "Conformance",
+                      "description": "The conformance of the claim meeting a requirement.",
+                      "additionalProperties": false,
+                      "properties": {
+                        "score": {
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1,
+                          "title": "Score",
+                          "description": "The conformance of the claim between and inclusive of 0 and 1, where 1 is 100% conformance."
+                        },
+                        "rationale": {
+                          "type": "string",
+                          "title": "Rationale",
+                          "description": "The rationale for the conformance score."
+                        },
+                        "mitigationStrategies": {
+                          "type": "array",
+                          "title": "Mitigation Strategies",
+                          "description": "The list of  `bom-ref` to the evidence provided describing the mitigation strategies.",
+                          "items": { "$ref": "#/definitions/refLinkType" }
+                        }
+                      }
+                    },
+                    "confidence": {
+                      "type": "object",
+                      "title": "Confidence",
+                      "description": "The confidence of the claim meeting the requirement.",
+                      "additionalProperties": false,
+                      "properties": {
+                        "score": {
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1,
+                          "title": "Score",
+                          "description": "The confidence of the claim between and inclusive of 0 and 1, where 1 is 100% confidence."
+                        },
+                        "rationale": {
+                          "type": "string",
+                          "title": "Rationale",
+                          "description": "The rationale for the confidence score."
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "signature": {
+                "$ref": "#/definitions/signature",
+                "title": "Signature",
+                "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+              }
+            }
+          }
+        },
+        "claims": {
+          "type": "array",
+          "title": "Claims",
+          "description": "The list of claims.",
+          "items": {
+            "type": "object",
+            "title": "Claim",
+            "additionalProperties": false,
+            "properties": {
+              "bom-ref": {
+                "$ref": "#/definitions/refType",
+                "title": "BOM Reference",
+                "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
+              },
+              "target": {
+                "$ref": "#/definitions/refLinkType",
+                "title": "Target",
+                "description": "The `bom-ref` to a target representing a specific system, application, API, module, team, person, process, business unit, company, etc...  that this claim is being applied to."
+              },
+              "predicate": {
+                "type": "string",
+                "title": "Predicate",
+                "description": "The specific statement or assertion about the target."
+              },
+              "mitigationStrategies": {
+                "type": "array",
+                "title": "Mitigation Strategies",
+                "description": "The list of  `bom-ref` to the evidence provided describing the mitigation strategies. Each mitigation strategy should include an explanation of how any weaknesses in the evidence will be mitigated.",
+                "items": { "$ref": "#/definitions/refLinkType" }
+              },
+              "reasoning": {
+                "type": "string",
+                "title": "Reasoning",
+                "description": "The written explanation of why the evidence provided substantiates the claim."
+              },
+              "evidence": {
+                "type": "array",
+                "title": "Evidence",
+                "description": "The list of `bom-ref` to evidence that supports this claim.",
+                "items": { "$ref": "#/definitions/refLinkType" }
+              },
+              "counterEvidence": {
+                "type": "array",
+                "title": "Counter Evidence",
+                "description": "The list of `bom-ref` to counterEvidence that supports this claim.",
+                "items": { "$ref": "#/definitions/refLinkType" }
+              },
+              "externalReferences": {
+                "type": "array",
+                "items": {"$ref": "#/definitions/externalReference"},
+                "title": "External References",
+                "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+              },
+              "signature": {
+                "$ref": "#/definitions/signature",
+                "title": "Signature",
+                "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+              }
+            }
+          }
+        },
+        "evidence": {
+          "type": "array",
+          "title": "Evidence",
+          "description": "The list of evidence",
+          "items": {
+            "type": "object",
+            "title": "Evidence",
+            "additionalProperties": false,
+            "properties": {
+              "bom-ref": {
+                "$ref": "#/definitions/refType",
+                "title": "BOM Reference",
+                "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
+              },
+              "propertyName": {
+                "type": "string",
+                "title": "Property Name",
+                "description": "The reference to the property name as defined in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy/)."
+              },
+              "description": {
+                "type": "string",
+                "title": "Description",
+                "description": "The written description of what this evidence is and how it was created."
+              },
+              "data": {
+                "type": "array",
+                "title": "Data",
+                "description": "The output or analysis that supports claims.",
+                "items": {
+                  "type": "object",
+                  "title": "Data",
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "title": "Data Name",
+                      "description": "The name of the data.",
+                      "type": "string"
+                    },
+                    "contents": {
+                      "type": "object",
+                      "title": "Data Contents",
+                      "description": "The contents or references to the contents of the data being described.",
+                      "additionalProperties": false,
+                      "properties": {
+                        "attachment": {
+                          "title": "Data Attachment",
+                          "description": "A way to include textual or encoded data.",
+                          "$ref": "#/definitions/attachment"
+                        },
+                        "url": {
+                          "type": "string",
+                          "title": "Data URL",
+                          "description": "The URL to where the data can be retrieved.",
+                          "format": "iri-reference"
+                        }
+                      }
+                    },
+                    "classification": {
+                      "$ref": "#/definitions/dataClassification"
+                    },
+                    "sensitiveData": {
+                      "type": "array",
+                      "title": "Sensitive Data",
+                      "description": "A description of any sensitive data included.",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "governance": {
+                      "title": "Data Governance",
+                      "$ref": "#/definitions/dataGovernance"
+                    }
+                  }
+                }
+              },
+              "created": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Created",
+                "description": "The date and time (timestamp) when the evidence was created."
+              },
+              "expires": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Expires",
+                "description": "The date and time (timestamp) when the evidence is no longer valid."
+              },
+              "author": {
+                "$ref": "#/definitions/organizationalContact",
+                "title": "Author",
+                "description": "The author of the evidence."
+              },
+              "reviewer": {
+                "$ref": "#/definitions/organizationalContact",
+                "title": "Reviewer",
+                "description": "The reviewer of the evidence."
+              },
+              "signature": {
+                "$ref": "#/definitions/signature",
+                "title": "Signature",
+                "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+              }
+            }
+          }
+        },
+        "targets": {
+          "type": "object",
+          "title": "Targets",
+          "description": "The list of targets which claims are made against.",
+          "additionalProperties": false,
+          "properties": {
+            "organizations": {
+              "type": "array",
+              "title": "Organizations",
+              "description": "The list of organizations which claims are made against.",
+              "items": {"$ref": "#/definitions/organizationalEntity"}
+            },
+            "components": {
+              "type": "array",
+              "title": "Components",
+              "description": "The list of components which claims are made against.",
+              "items": {"$ref": "#/definitions/component"}
+            },
+            "services": {
+              "type": "array",
+              "title": "Services",
+              "description": "The list of services which claims are made against.",
+              "items": {"$ref": "#/definitions/service"}
+            }
+          }
+        },
+        "affirmation": {
+          "type": "object",
+          "title": "Affirmation",
+          "description": "A concise statement affirmed by an individual regarding all declarations, often used for third-party auditor acceptance or recipient acknowledgment. It includes a list of authorized signatories who assert the validity of the document on behalf of the organization.",
+          "additionalProperties": false,
+          "properties": {
+            "statement": {
+              "type": "string",
+              "title": "Statement",
+              "description": "The brief statement affirmed by an individual regarding all declarations.\n*- Notes This could be an affirmation of acceptance by a third-party auditor or receiving individual of a file.",
+              "examples": [ "I certify, to the best of my knowledge, that all information is correct." ]
+            },
+            "signatories": {
+              "type": "array",
+              "title": "Signatories",
+              "description": "The list of signatories authorized on behalf of an organization to assert validity of this document.",
+              "items": {
+                "type": "object",
+                "title": "Signatory",
+                "additionalProperties": false,
+                "oneOf": [
+                  {
+                    "required": ["signature"]
+                  },
+                  {
+                    "required": ["externalReference", "organization"]
+                  }
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The signatory's name."
+                  },
+                  "role": {
+                    "type": "string",
+                    "title": "Role",
+                    "description": "The signatory's role within an organization."
+                  },
+                  "signature": {
+                    "$ref": "#/definitions/signature",
+                    "title": "Signature",
+                    "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+                  },
+                  "organization": {
+                    "$ref": "#/definitions/organizationalEntity",
+                    "title": "Organization",
+                    "description": "The signatory's organization."
+                  },
+                  "externalReference": {
+                    "$ref": "#/definitions/externalReference",
+                    "title": "External Reference",
+                    "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+                  }
+                }
+              }
+            },
+            "signature": {
+              "$ref": "#/definitions/signature",
+              "title": "Signature",
+              "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+            }
+          }
+        },
+        "signature": {
+          "$ref": "#/definitions/signature",
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+        }
+      }
+    },
+    "definitions": {
+      "type": "object",
+      "title": "Definitions",
+      "description": "A collection of reusable objects that are defined and may be used elsewhere in the BOM.",
+      "additionalProperties": false,
+      "properties": {
+        "standards": {
+          "type": "array",
+          "title": "Standards",
+          "description": "The list of standards which may consist of regulations, industry or organizational-specific standards, maturity models, best practices, or any other requirements which can be evaluated against or attested to.",
+          "items": {
+            "$ref": "#/definitions/standard"
+          }
+        },
+        "patents": {
+          "type": "array",
+          "title": "Patents",
+          "description": "The list of either individual patents or patent families.",
+          "items": {
+            "anyOf": [
+              { "$ref": "#/definitions/patent" },
+              { "$ref": "#/definitions/patentFamily" }
+            ]
+          }
+        }
+      }
+    },
+    "citations": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/citation"},
+      "uniqueItems": true,
+      "title": "Citations",
+      "description": "A collection of attributions indicating which entity supplied information for specific fields within the BOM."
+    },
+    "properties": {
+      "type": "array",
+      "title": "Properties",
+      "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+      "items": {
+        "$ref": "#/definitions/property"
+      }
+    },
+    "signature": {
+      "$ref": "#/definitions/signature",
+      "title": "Signature",
+      "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+    }
+  },
+  "definitions": {
+    "refType": {
+      "title": "BOM Reference",
+      "description": "Identifier for referable and therefore interlinkable elements.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+      "type": "string",
+      "minLength": 1,
+      "$comment": "TODO (breaking change): add a format constraint that prevents the value from staring with 'urn:cdx:'"
+    },
+    "refLinkType": {
+      "title": "BOM Reference",
+      "description": "Descriptor for an element identified by the attribute 'bom-ref' in the same BOM document.\nIn contrast to `bomLinkElementType`.",
+      "$ref": "#/definitions/refType"
+    },
+    "bomLinkDocumentType": {
+      "title": "BOM-Link Document",
+      "description": "Descriptor for another BOM document. See https://cyclonedx.org/capabilities/bomlink/",
+      "type": "string",
+      "format": "iri-reference",
+      "pattern": "^urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*$",
+      "$comment": "part of the pattern is based on `bom.serialNumber`'s pattern"
+    },
+    "bomLinkElementType": {
+      "title": "BOM-Link Element",
+      "description": "Descriptor for an element in a BOM document. See https://cyclonedx.org/capabilities/bomlink/",
+      "type": "string",
+      "format": "iri-reference",
+      "pattern": "^urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*#.+$",
+      "$comment": "part of the pattern is based on `bom.serialNumber`'s pattern"
+    },
+    "bomLink": {
+      "title": "BOM-Link",
+      "anyOf": [
+        {
+          "title": "BOM-Link Document",
+          "$ref": "#/definitions/bomLinkDocumentType"
+        },
+        {
+          "title": "BOM-Link Element",
+          "$ref": "#/definitions/bomLinkElementType"
+        }
+      ]
+    },
+    "metadata": {
+      "type": "object",
+      "title": "BOM Metadata",
+      "additionalProperties": false,
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Timestamp",
+          "description": "The date and time (timestamp) when the BOM was created."
+        },
+        "lifecycles": {
+          "type": "array",
+          "title": "Lifecycles",
+          "description": "Lifecycles communicate the stage(s) in which data in the BOM was captured. Different types of data may be available at various phases of a lifecycle, such as the Software Development Lifecycle (SDLC), IT Asset Management (ITAM), and Software Asset Management (SAM). Thus, a BOM may include data specific to or only obtainable in a given lifecycle.",
+          "items": {
+            "type": "object",
+            "title": "Lifecycle",
+            "description": "The product lifecycle(s) that this BOM represents.",
+            "oneOf": [
+              {
+                "title": "Pre-Defined Phase",
+                "required": ["phase"],
+                "additionalProperties": false,
+                "properties": {
+                  "phase": {
+                    "type": "string",
+                    "title": "Phase",
+                    "description": "A pre-defined phase in the product lifecycle.",
+                    "enum": [
+                      "design",
+                      "pre-build",
+                      "build",
+                      "post-build",
+                      "operations",
+                      "discovery",
+                      "decommission"
+                    ],
+                    "meta:enum": {
+                      "design": "BOM produced early in the development lifecycle containing an inventory of components and services that are proposed or planned to be used. The inventory may need to be procured, retrieved, or resourced prior to use.",
+                      "pre-build": "BOM consisting of information obtained prior to a build process and may contain source files and development artifacts and manifests. The inventory may need to be resolved and retrieved prior to use.",
+                      "build": "BOM consisting of information obtained during a build process where component inventory is available for use. The precise versions of resolved components are usually available at this time as well as the provenance of where the components were retrieved from.",
+                      "post-build": "BOM consisting of information obtained after a build process has completed and the resulting components(s) are available for further analysis. Built components may exist as the result of a CI/CD process, may have been installed or deployed to a system or device, and may need to be retrieved or extracted from the system or device.",
+                      "operations": "BOM produced that represents inventory that is running and operational. This may include staging or production environments and will generally encompass multiple SBOMs describing the applications and operating system, along with HBOMs describing the hardware that makes up the system. Operations Bill of Materials (OBOM) can provide full-stack inventory of runtime environments, configurations, and additional dependencies.",
+                      "discovery": "BOM consisting of information observed through network discovery providing point-in-time enumeration of embedded, on-premise, and cloud-native services such as server applications, connected devices, microservices, and serverless functions.",
+                      "decommission": "BOM containing inventory that will be, or has been retired from operations."
+                    }
+                  }
+                }
+              },
+              {
+                "title": "Custom Phase",
+                "required": ["name"],
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The name of the lifecycle phase"
+                  },
+                  "description": {
+                    "type": "string",
+                    "title": "Description",
+                    "description": "The description of the lifecycle phase"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "tools": {
+          "title": "Tools",
+          "description": "The tool(s) used in the creation, enrichment, and validation of the BOM.",
+          "oneOf": [
+            {
+              "type": "object",
+              "title": "Tools",
+              "description": "The tool(s) used in the creation, enrichment, and validation of the BOM.",
+              "additionalProperties": false,
+              "properties": {
+                "components": {
+                  "type": "array",
+                  "items": {"$ref": "#/definitions/component"},
+                  "uniqueItems": true,
+                  "title": "Components",
+                  "description": "A list of software and hardware components used as tools."
+                },
+                "services": {
+                  "type": "array",
+                  "items": {"$ref": "#/definitions/service"},
+                  "uniqueItems": true,
+                  "title": "Services",
+                  "description": "A list of services used as tools. This may include microservices, function-as-a-service, and other types of network or intra-process services."
+                }
+              }
+            },
+            {
+              "type": "array",
+              "title": "Tools (legacy)",
+              "description": "[Deprecated]\nThe tool(s) used in the creation, enrichment, and validation of the BOM.",
+              "deprecated": true,
+              "items": {"$ref": "#/definitions/tool"}
+            }
+          ]
+        },
+        "manufacturer": {
+          "title": "BOM Manufacturer",
+          "description": "The organization that created the BOM.\nManufacturer is common in BOMs created through automated processes. BOMs created through manual means may have `@.authors` instead.",
+          "$ref": "#/definitions/organizationalEntity"
+        },
+        "authors": {
+          "type": "array",
+          "title": "BOM Authors",
+          "description": "The person(s) who created the BOM.\nAuthors are common in BOMs created through manual processes. BOMs created through automated means may have `@.manufacturer` instead.",
+          "items": {"$ref": "#/definitions/organizationalContact"}
+        },
+        "component": {
+          "title": "Component",
+          "description": "The component that the BOM describes.",
+          "$ref": "#/definitions/component"
+        },
+        "manufacture": {
+          "deprecated": true,
+          "title": "Component Manufacture (legacy)",
+          "description": "[Deprecated] This will be removed in a future version. Use the `@.component.manufacturer` instead.\nThe organization that manufactured the component that the BOM describes.",
+          "$ref": "#/definitions/organizationalEntity"
+        },
+        "supplier": {
+          "title": "Supplier",
+          "description": " The organization that supplied the component that the BOM describes. The supplier may often be the manufacturer, but may also be a distributor or repackager.",
+          "$ref": "#/definitions/organizationalEntity"
+        },
+        "licenses": {
+          "title": "BOM License(s)",
+          "description": "The license information for the BOM document.\nThis may be different from the license(s) of the component(s) that the BOM describes.",
+          "$ref": "#/definitions/licenseChoice"
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {"$ref": "#/definitions/property"}
+        },
+        "distributionConstraints": {
+          "title": "Distribution Constraints",
+          "description": "Conditions and constraints governing the sharing and distribution of the data or components described by this BOM.",
+          "type": "object",
+          "properties": {
+            "tlp": {
+              "$ref": "#/definitions/tlpClassification",
+              "description": "The Traffic Light Protocol (TLP) classification that controls the sharing and distribution of the data that the BOM describes."
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "tlpClassification": {
+      "title": "Traffic Light Protocol (TLP) Classification",
+      "description": "Traffic Light Protocol (TLP) is a classification system for identifying the potential risk associated with artefact, including whether it is subject to certain types of legal, financial, or technical threats. Refer to [https://www.first.org/tlp/](https://www.first.org/tlp/) for further information.\nThe default classification is \"CLEAR\"",
+      "type" : "string",
+      "default": "CLEAR",
+      "enum": [
+        "CLEAR",
+        "GREEN",
+        "AMBER",
+        "AMBER_AND_STRICT",
+        "RED"
+      ],
+      "meta:enum": {
+        "CLEAR": "The information is not subject to any restrictions as regards the sharing.",
+        "GREEN": "The information is subject to limited disclosure, and recipients can share it within their community but not via publicly accessible channels.",
+        "AMBER": "The information is subject to limited disclosure, and recipients can only share it on a need-to-know basis within their organization and with clients.",
+        "AMBER_AND_STRICT": "The information is subject to limited disclosure, and recipients can only share it on a need-to-know basis within their organization.",
+        "RED": "The information is subject to restricted distribution to individual recipients only and must not be shared."
+      }
+    },
+    "tool": {
+      "type": "object",
+      "title": "Tool",
+      "description": "[Deprecated] This will be removed in a future version. Use component or service instead.\nInformation about the automated or manual tool used",
+      "additionalProperties": false,
+      "deprecated": true,
+      "properties": {
+        "vendor": {
+          "type": "string",
+          "title": "Tool Vendor",
+          "description": "The name of the vendor who created the tool"
+        },
+        "name": {
+          "type": "string",
+          "title": "Tool Name",
+          "description": "The name of the tool"
+        },
+        "version": {
+          "$ref": "#/definitions/version",
+          "title": "Tool Version",
+          "description": "The version of the tool"
+        },
+        "hashes": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/hash"},
+          "title": "Hashes",
+          "description": "The hashes of the tool (if applicable)."
+        },
+        "externalReferences": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/externalReference"},
+          "title": "External References",
+          "description": "External references provide a way to document systems, sites, and information that may be relevant, but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+        }
+      }
+    },
+    "organizationalEntity": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+        },
+        "name": {
+          "type": "string",
+          "title": "Organization Name",
+          "description": "The name of the organization",
+          "examples": [
+            "Example Inc."
+          ]
+        },
+        "address": {
+          "$ref": "#/definitions/postalAddress",
+          "title": "Organization Address",
+          "description": "The physical address (location) of the organization"
+        },
+        "url": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "iri-reference"
+          },
+          "title": "Organization URL(s)",
+          "description": "The URL of the organization. Multiple URLs are allowed.",
+          "examples": ["https://example.com"]
+        },
+        "contact": {
+          "type": "array",
+          "title": "Organizational Contact",
+          "description": "A contact at the organization. Multiple contacts are allowed.",
+          "items": {"$ref": "#/definitions/organizationalContact"}
+        }
+      }
+    },
+    "organizationalContact": {
+      "type": "object",
+      "additionalProperties": false,
+      "title": "Organizational Person",
+      "properties": {
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of a contact",
+          "examples": ["Contact name"]
+        },
+        "email": {
+          "type": "string",
+          "format": "idn-email",
+          "title": "Email Address",
+          "description": "The email address of the contact.",
+          "examples": ["firstname.lastname@example.com"]
+        },
+        "phone": {
+          "type": "string",
+          "title": "Phone",
+          "description": "The phone number of the contact.",
+          "examples": ["800-555-1212"]
+        }
+      }
+    },
+    "component": {
+      "type": "object",
+      "title": "Component",
+      "required": [
+        "type",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "application",
+            "framework",
+            "library",
+            "container",
+            "platform",
+            "operating-system",
+            "device",
+            "device-driver",
+            "firmware",
+            "file",
+            "machine-learning-model",
+            "data",
+            "cryptographic-asset"
+          ],
+          "meta:enum": {
+            "application": "A software application. Refer to [https://en.wikipedia.org/wiki/Application_software](https://en.wikipedia.org/wiki/Application_software) for information about applications.",
+            "framework": "A software framework. Refer to [https://en.wikipedia.org/wiki/Software_framework](https://en.wikipedia.org/wiki/Software_framework) for information on how frameworks vary slightly from libraries.",
+            "library": "A software library. Refer to [https://en.wikipedia.org/wiki/Library_(computing)](https://en.wikipedia.org/wiki/Library_(computing)) for information about libraries. All third-party and open source reusable components will likely be a library. If the library also has key features of a framework, then it should be classified as a framework. If not, or is unknown, then specifying library is recommended.",
+            "container": "A packaging and/or runtime format, not specific to any particular technology, which isolates software inside the container from software outside of a container through virtualization technology. Refer to [https://en.wikipedia.org/wiki/OS-level_virtualization](https://en.wikipedia.org/wiki/OS-level_virtualization).",
+            "platform": "A runtime environment that interprets or executes software. This may include runtimes such as those that execute bytecode, just-in-time compilers, interpreters, or low-code/no-code application platforms.",
+            "operating-system": "A software operating system without regard to deployment model (i.e. installed on physical hardware, virtual machine, image, etc) Refer to [https://en.wikipedia.org/wiki/Operating_system](https://en.wikipedia.org/wiki/Operating_system).",
+            "device": "A hardware device such as a processor or chip-set. A hardware device containing firmware SHOULD include a component for the physical hardware itself and another component of type 'firmware' or 'operating-system' (whichever is relevant), describing information about the software running on the device. See also the list of [known device properties](https://github.com/CycloneDX/cyclonedx-property-taxonomy/blob/main/cdx/device.md).",
+            "device-driver": "A special type of software that operates or controls a particular type of device. Refer to [https://en.wikipedia.org/wiki/Device_driver](https://en.wikipedia.org/wiki/Device_driver).",
+            "firmware": "A special type of software that provides low-level control over a device's hardware. Refer to [https://en.wikipedia.org/wiki/Firmware](https://en.wikipedia.org/wiki/Firmware).",
+            "file": "A computer file. Refer to [https://en.wikipedia.org/wiki/Computer_file](https://en.wikipedia.org/wiki/Computer_file) for information about files.",
+            "machine-learning-model": "A model based on training data that can make predictions or decisions without being explicitly programmed to do so.",
+            "data": "A collection of discrete values that convey information.",
+            "cryptographic-asset": "A cryptographic asset including algorithms, protocols, certificates, keys, tokens, and secrets."
+          },
+          "title": "Component Type",
+          "description": "Specifies the type of component. For software components, classify as application if no more specific appropriate classification is available or cannot be determined for the component.",
+          "examples": ["library"]
+        },
+        "mime-type": {
+          "type": "string",
+          "title": "Mime-Type",
+          "description": "The mime-type of the component. When used on file components, the mime-type can provide additional context about the kind of file being represented, such as an image, font, or executable. Some library or framework components may also have an associated mime-type.",
+          "examples": ["image/jpeg"],
+          "pattern": "^[-+a-z0-9.]+/[-+a-z0-9.]+$"
+        },
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the component elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+        },
+        "supplier": {
+          "title": "Component Supplier",
+          "description": " The organization that supplied the component. The supplier may often be the manufacturer, but may also be a distributor or repackager.",
+          "$ref": "#/definitions/organizationalEntity"
+        },
+        "manufacturer": {
+          "title": "Component Manufacturer",
+          "description": "The organization that created the component.\nManufacturer is common in components created through automated processes. Components created through manual means may have `@.authors` instead.",
+          "$ref": "#/definitions/organizationalEntity"
+        },
+        "authors" :{
+          "type": "array",
+          "title": "Component Authors",
+          "description": "The person(s) who created the component.\nAuthors are common in components created through manual processes. Components created through automated means may have `@.manufacturer` instead.",
+          "items": {"$ref": "#/definitions/organizationalContact"}
+        },
+        "author": {
+          "deprecated": true,
+          "type": "string",
+          "title": "Component Author (legacy)",
+          "description": "[Deprecated] This will be removed in a future version. Use `@.authors` or `@.manufacturer` instead.\nThe person(s) or organization(s) that authored the component",
+          "examples": ["Acme Inc"]
+        },
+        "publisher": {
+          "type": "string",
+          "title": "Component Publisher",
+          "description": "The person(s) or organization(s) that published the component",
+          "examples": ["Acme Inc"]
+        },
+        "group": {
+          "type": "string",
+          "title": "Component Group",
+          "description": "The grouping name or identifier. This will often be a shortened, single name of the company or project that produced the component, or the source package or domain name. Whitespace and special characters should be avoided. Examples include: apache, org.apache.commons, and apache.org.",
+          "examples": ["com.acme"]
+        },
+        "name": {
+          "type": "string",
+          "title": "Component Name",
+          "description": "The name of the component. This will often be a shortened, single name of the component. Examples: commons-lang3 and jquery",
+          "examples": ["tomcat-catalina"]
+        },
+        "version": {
+          "$ref": "#/definitions/version",
+          "title": "Component Version",
+          "description": "The component version. The version should ideally comply with semantic versioning but is not enforced.\nMust be used exclusively, either 'version' or 'versionRange', but not both."
+        },
+        "versionRange": {
+          "$ref": "#/definitions/versionRange",
+          "title": "Component Version Range",
+          "description": "For an external component, this specifies the accepted version range.\nThe value must adhere to the Package URL Version Range syntax (vers), as defined at https://github.com/package-url/vers-spec\nMay only be used if `.isExternal` is set to `true`.\nMust be used exclusively, either 'version' or 'versionRange', but not both."
+        },
+        "isExternal": {
+          "type": "boolean",
+          "title": "Component Is External",
+          "description": "Determine whether this component is external.\nAn external component is one that is not part of an assembly, but is expected to be provided by the environment, regardless of the component's `.scope`. This setting can be useful for distinguishing which components are bundled with the product and which can be relied upon to be present in the deployment environment.\nThis may be set to `true` for runtime components only. For `$.metadata.component`, it must be set to `false`.",
+          "default": false
+        },
+        "description": {
+          "type": "string",
+          "title": "Component Description",
+          "description": "Specifies a description for the component"
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "required",
+            "optional",
+            "excluded"
+          ],
+          "meta:enum": {
+            "required": "The component is required for runtime",
+            "optional": "The component is optional at runtime. Optional components are components that are not capable of being called due to them not being installed or otherwise accessible by any means. Components that are installed but due to configuration or other restrictions are prohibited from being called must be scoped as 'required'.",
+            "excluded": "Components that are excluded provide the ability to document component usage for test and other non-runtime purposes. Excluded components are not reachable within a call graph at runtime."
+          },
+          "title": "Component Scope",
+          "description": "Specifies the scope of the component. If scope is not specified, 'required' scope SHOULD be assumed by the consumer of the BOM.",
+          "default": "required"
+        },
+        "hashes": {
+          "type": "array",
+          "title": "Component Hashes",
+          "description": "The hashes of the component.",
+          "items": {"$ref": "#/definitions/hash"}
+        },
+        "licenses": {
+          "$ref": "#/definitions/licenseChoice",
+          "title": "Component License(s)"
+        },
+        "copyright": {
+          "type": "string",
+          "title": "Component Copyright",
+          "description": "A copyright notice informing users of the underlying claims to copyright ownership in a published work.",
+          "examples": ["Acme Inc"]
+        },
+        "patentAssertions": {
+          "$ref": "#/definitions/patentAssertions",
+          "title": "Component Patent(s)"
+        },
+        "cpe": {
+          "type": "string",
+          "title": "Common Platform Enumeration (CPE)",
+          "description": "Asserts the identity of the component using CPE. The CPE must conform to the CPE 2.2 or 2.3 specification. See [https://nvd.nist.gov/products/cpe](https://nvd.nist.gov/products/cpe). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity.",
+          "examples": ["cpe:2.3:a:acme:component_framework:-:*:*:*:*:*:*:*"]
+        },
+        "purl": {
+          "type": "string",
+          "title": "Package URL (purl)",
+          "description": "Asserts the identity of the component using package-url (purl). The purl, if specified, must be valid and conform to the specification defined at: [https://github.com/package-url/purl-spec](https://github.com/package-url/purl-spec). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity.",
+          "examples": ["pkg:maven/com.acme/tomcat-catalina@9.0.14?packaging=jar"]
+        },
+        "omniborId": {
+          "type": "array",
+          "title": "OmniBOR Artifact Identifier (gitoid)",
+          "description": "Asserts the identity of the component using the OmniBOR Artifact ID. The OmniBOR, if specified, must be valid and conform to the specification defined at: [https://www.iana.org/assignments/uri-schemes/prov/gitoid](https://www.iana.org/assignments/uri-schemes/prov/gitoid). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity.",
+          "items": { "type": "string" },
+          "examples": [
+            "gitoid:blob:sha1:a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+            "gitoid:blob:sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+          ]
+        },
+        "swhid": {
+          "type": "array",
+          "title": "Software Heritage Identifier",
+          "description": "Asserts the identity of the component using the Software Heritage persistent identifier (SWHID). The SWHID, if specified, must be valid and conform to the specification defined at: [https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html](https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity.",
+          "items": { "type": "string" },
+          "examples": ["swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2"]
+        },
+        "swid": {
+          "$ref": "#/definitions/swid",
+          "title": "SWID Tag",
+          "description": "Asserts the identity of the component using [ISO-IEC 19770-2 Software Identification (SWID) Tags](https://www.iso.org/standard/65666.html). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity."
+        },
+        "modified": {
+          "type": "boolean",
+          "title": "Component Modified From Original",
+          "description": "[Deprecated] This will be removed in a future version. Use the pedigree element instead to supply information on exactly how the component was modified.\nA boolean value indicating if the component has been modified from the original. A value of true indicates the component is a derivative of the original. A value of false indicates the component has not been modified from the original.",
+          "deprecated": true
+        },
+        "pedigree": {
+          "type": "object",
+          "title": "Component Pedigree",
+          "description": "Component pedigree is a way to document complex supply chain scenarios where components are created, distributed, modified, redistributed, combined with other components, etc. Pedigree supports viewing this complex chain from the beginning, the end, or anywhere in the middle. It also provides a way to document variants where the exact relation may not be known.",
+          "additionalProperties": false,
+          "properties": {
+            "ancestors": {
+              "type": "array",
+              "title": "Ancestors",
+              "description": "Describes zero or more components in which a component is derived from. This is commonly used to describe forks from existing projects where the forked version contains an ancestor node containing the original component it was forked from. For example, Component A is the original component. Component B is the component being used and documented in the BOM. However, Component B contains a pedigree node with a single ancestor documenting Component A - the original component from which Component B is derived from.",
+              "items": {"$ref": "#/definitions/component"}
+            },
+            "descendants": {
+              "type": "array",
+              "title": "Descendants",
+              "description": "Descendants are the exact opposite of ancestors. This provides a way to document all forks (and their forks) of an original or root component.",
+              "items": {"$ref": "#/definitions/component"}
+            },
+            "variants": {
+              "type": "array",
+              "title": "Variants",
+              "description": "Variants describe relations where the relationship between the components is not known. For example, if Component A contains nearly identical code to Component B. They are both related, but it is unclear if one is derived from the other, or if they share a common ancestor.",
+              "items": {"$ref": "#/definitions/component"}
+            },
+            "commits": {
+              "type": "array",
+              "title": "Commits",
+              "description": "A list of zero or more commits which provide a trail describing how the component deviates from an ancestor, descendant, or variant.",
+              "items": {"$ref": "#/definitions/commit"}
+            },
+            "patches": {
+              "type": "array",
+              "title": "Patches",
+              "description": "A list of zero or more patches describing how the component deviates from an ancestor, descendant, or variant. Patches may be complementary to commits or may be used in place of commits.",
+              "items": {"$ref": "#/definitions/patch"}
+            },
+            "notes": {
+              "type": "string",
+              "title": "Notes",
+              "description": "Notes, observations, and other non-structured commentary describing the components pedigree."
+            }
+          }
+        },
+        "externalReferences": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/externalReference"},
+          "title": "External References",
+          "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+        },
+        "components": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/component"},
+          "uniqueItems": true,
+          "title": "Components",
+          "description": "A list of software and hardware components included in the parent component. This is not a dependency tree. It provides a way to specify a hierarchical representation of component assemblies, similar to system &#8594; subsystem &#8594; parts assembly in physical supply chains."
+        },
+        "evidence": {
+          "$ref": "#/definitions/componentEvidence",
+          "title": "Evidence",
+          "description": "Provides the ability to document evidence collected through various forms of extraction or analysis."
+        },
+        "releaseNotes": {
+          "$ref": "#/definitions/releaseNotes",
+          "title": "Release notes",
+          "description": "Specifies release notes."
+        },
+        "modelCard": {
+          "$ref": "#/definitions/modelCard",
+          "title": "AI/ML Model Card"
+        },
+        "data": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/componentData"},
+          "title": "Data",
+          "description": "This object SHOULD be specified for any component of type `data` and must not be specified for other component types."
+        },
+        "cryptoProperties": {
+          "$ref": "#/definitions/cryptoProperties",
+          "title": "Cryptographic Properties"
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {"$ref": "#/definitions/property"}
+        },
+        "tags": {
+          "$ref": "#/definitions/tags",
+          "title": "Tags"
+        },
+        "signature": {
+          "$ref": "#/definitions/signature",
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+        }
+      },
+      "allOf": [
+        {
+          "description": "Requirement: ensure that `version` and `versionRange` are not present simultaneously.",
+          "not": {
+            "required": ["version", "versionRange"]
+          }
+        },
+        {
+          "description": "Requirement: 'versionRange' must not be present when 'isExternal' is `false`.",
+          "if": {
+            "properties": { "isExternal": { "const": false } }
+          },
+          "then": {
+            "not": { "required": ["versionRange"] }
+          },
+          "else": true
+        }
+      ]
+    },
+    "swid": {
+      "type": "object",
+      "title": "SWID Tag",
+      "description": "Specifies metadata and content for ISO-IEC 19770-2 Software Identification (SWID) Tags.",
+      "required": [
+        "tagId",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "tagId": {
+          "type": "string",
+          "title": "Tag ID",
+          "description": "Maps to the tagId of a SoftwareIdentity."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "Maps to the name of a SoftwareIdentity."
+        },
+        "version": {
+          "type": "string",
+          "title": "Version",
+          "default": "0.0",
+          "description": "Maps to the version of a SoftwareIdentity."
+        },
+        "tagVersion": {
+          "type": "integer",
+          "title": "Tag Version",
+          "default": 0,
+          "description": "Maps to the tagVersion of a SoftwareIdentity."
+        },
+        "patch": {
+          "type": "boolean",
+          "title": "Patch",
+          "default": false,
+          "description": "Maps to the patch of a SoftwareIdentity."
+        },
+        "text": {
+          "title": "Attachment text",
+          "description": "Specifies the metadata and content of the SWID tag.",
+          "$ref": "#/definitions/attachment"
+        },
+        "url": {
+          "type": "string",
+          "title": "URL",
+          "description": "The URL to the SWID file.",
+          "format": "iri-reference"
+        }
+      }
+    },
+    "attachment": {
+      "type": "object",
+      "title": "Attachment",
+      "description": "Specifies the metadata and content for an attachment.",
+      "required": [
+        "content"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "contentType": {
+          "type": "string",
+          "title": "Content-Type",
+          "description": "Specifies the format and nature of the data being attached, helping systems correctly interpret and process the content. Common content type examples include `application/json` for JSON data and `text/plain` for plan text documents.\n [RFC 2045 section 5.1](https://www.ietf.org/rfc/rfc2045.html#section-5.1) outlines the structure and use of content types. For a comprehensive list of registered content types, refer to the [IANA media types registry](https://www.iana.org/assignments/media-types/media-types.xhtml).",
+          "default": "text/plain",
+          "examples": [
+            "text/plain",
+            "application/json",
+            "image/png"
+          ]
+        },
+        "encoding": {
+          "type": "string",
+          "title": "Encoding",
+          "description": "Specifies the encoding the text is represented in.",
+          "enum": [
+            "base64"
+          ],
+          "meta:enum": {
+            "base64": "Base64 is a binary-to-text encoding scheme that represents binary data in an ASCII string."
+          }
+        },
+        "content": {
+          "type": "string",
+          "title": "Attachment Text",
+          "description": "The attachment data. Proactive controls such as input validation and sanitization should be employed to prevent misuse of attachment text."
+        }
+      }
+    },
+    "hash": {
+      "type": "object",
+      "title": "Hash",
+      "required": [
+        "alg",
+        "content"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alg": {
+          "$ref": "#/definitions/hash-alg"
+        },
+        "content": {
+          "$ref": "#/definitions/hash-content"
+        }
+      }
+    },
+    "hash-alg": {
+      "type": "string",
+      "title": "Hash Algorithm",
+      "description": "The algorithm that generated the hash value.",
+      "enum": [
+        "MD5",
+        "SHA-1",
+        "SHA-256",
+        "SHA-384",
+        "SHA-512",
+        "SHA3-256",
+        "SHA3-384",
+        "SHA3-512",
+        "BLAKE2b-256",
+        "BLAKE2b-384",
+        "BLAKE2b-512",
+        "BLAKE3",
+        "Streebog-256",
+        "Streebog-512"
+      ]
+    },
+    "hash-content": {
+      "type": "string",
+      "title": "Hash Value",
+      "description": "The value of the hash.",
+      "examples": ["3942447fac867ae5cdb3229b658f4d48"],
+      "pattern": "^([a-fA-F0-9]{32}|[a-fA-F0-9]{40}|[a-fA-F0-9]{64}|[a-fA-F0-9]{96}|[a-fA-F0-9]{128})$"
+    },
+    "licensing": {
+      "type": "object",
+      "title": "Licensing information",
+      "description": "Licensing details describing the licensor/licensee, license type, renewal and expiration dates, and other important metadata",
+      "additionalProperties": false,
+      "properties": {
+        "altIds": {
+          "type": "array",
+          "title": "Alternate License Identifiers",
+          "description": "License identifiers that may be used to manage licenses and their lifecycle",
+          "items": {
+            "type": "string"
+          }
+        },
+        "licensor": {
+          "title": "Licensor",
+          "description": "The individual or organization that grants a license to another individual or organization",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "organization": {
+              "title": "Licensor (Organization)",
+              "description": "The organization that granted the license",
+              "$ref": "#/definitions/organizationalEntity"
+            },
+            "individual": {
+              "title": "Licensor (Individual)",
+              "description": "The individual, not associated with an organization, that granted the license",
+              "$ref": "#/definitions/organizationalContact"
+            }
+          },
+          "oneOf":[
+            {
+              "required": ["organization"]
+            },
+            {
+              "required": ["individual"]
+            }
+          ]
+        },
+        "licensee": {
+          "title": "Licensee",
+          "description": "The individual or organization for which a license was granted to",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "organization": {
+              "title": "Licensee (Organization)",
+              "description": "The organization that was granted the license",
+              "$ref": "#/definitions/organizationalEntity"
+            },
+            "individual": {
+              "title": "Licensee (Individual)",
+              "description": "The individual, not associated with an organization, that was granted the license",
+              "$ref": "#/definitions/organizationalContact"
+            }
+          },
+          "oneOf":[
+            {
+              "required": ["organization"]
+            },
+            {
+              "required": ["individual"]
+            }
+          ]
+        },
+        "purchaser": {
+          "title": "Purchaser",
+          "description": "The individual or organization that purchased the license",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "organization": {
+              "title": "Purchaser (Organization)",
+              "description": "The organization that purchased the license",
+              "$ref": "#/definitions/organizationalEntity"
+            },
+            "individual": {
+              "title": "Purchaser (Individual)",
+              "description": "The individual, not associated with an organization, that purchased the license",
+              "$ref": "#/definitions/organizationalContact"
+            }
+          },
+          "oneOf":[
+            {
+              "required": ["organization"]
+            },
+            {
+              "required": ["individual"]
+            }
+          ]
+        },
+        "purchaseOrder": {
+          "type": "string",
+          "title": "Purchase Order",
+          "description": "The purchase order identifier the purchaser sent to a supplier or vendor to authorize a purchase"
+        },
+        "licenseTypes": {
+          "type": "array",
+          "title": "License Type",
+          "description": "The type of license(s) that was granted to the licensee.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "academic",
+              "appliance",
+              "client-access",
+              "concurrent-user",
+              "core-points",
+              "custom-metric",
+              "device",
+              "evaluation",
+              "named-user",
+              "node-locked",
+              "oem",
+              "perpetual",
+              "processor-points",
+              "subscription",
+              "user",
+              "other"
+            ],
+            "meta:enum": {
+              "academic": "A license that grants use of software solely for the purpose of education or research.",
+              "appliance": "A license covering use of software embedded in a specific piece of hardware.",
+              "client-access": "A Client Access License (CAL) allows client computers to access services provided by server software.",
+              "concurrent-user": "A Concurrent User license (aka floating license) limits the number of licenses for a software application and licenses are shared among a larger number of users.",
+              "core-points": "A license where the core of a computer's processor is assigned a specific number of points.",
+              "custom-metric": "A license for which consumption is measured by non-standard metrics.",
+              "device": "A license that covers a defined number of installations on computers and other types of devices.",
+              "evaluation": "A license that grants permission to install and use software for trial purposes.",
+              "named-user": "A license that grants access to the software to one or more pre-defined users.",
+              "node-locked": "A license that grants access to the software on one or more pre-defined computers or devices.",
+              "oem": "An Original Equipment Manufacturer license that is delivered with hardware, cannot be transferred to other hardware, and is valid for the life of the hardware.",
+              "perpetual": "A license where the software is sold on a one-time basis and the licensee can use a copy of the software indefinitely.",
+              "processor-points": "A license where each installation consumes points per processor.",
+              "subscription": "A license where the licensee pays a fee to use the software or service.",
+              "user": "A license that grants access to the software or service by a specified number of users.",
+              "other": "Another license type."
+            }
+          }
+        },
+        "lastRenewal": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Last Renewal",
+          "description": "The timestamp indicating when the license was last renewed. For new purchases, this is often the purchase or acquisition date. For non-perpetual licenses or subscriptions, this is the timestamp of when the license was last renewed."
+        },
+        "expiration": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Expiration",
+          "description": "The timestamp indicating when the current license expires (if applicable)."
+        }
+      }
+    },
+    "license": {
+      "type": "object",
+      "title": "License",
+      "description": "Specifies the details and attributes related to a software license. It can either include a valid SPDX license identifier or a named license, along with additional properties such as license acknowledgment, comprehensive commercial licensing information, and the full text of the license.",
+      "oneOf": [
+        {
+          "required": ["id"]
+        },
+        {
+          "required": ["name"]
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the license elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+        },
+        "id": {
+          "$ref": "spdx.schema.json",
+          "title": "License ID (SPDX)",
+          "description": "A valid SPDX license identifier. If specified, this value must be one of the enumeration of valid SPDX license identifiers defined in the spdx.schema.json (or spdx.xml) subschema which is synchronized with the official SPDX license list.",
+          "examples": ["Apache-2.0"]
+        },
+        "name": {
+          "type": "string",
+          "title": "License Name",
+          "description": "The name of the license. This may include the name of a commercial or proprietary license or an open source license that may not be defined by SPDX.",
+          "examples": ["Acme Software License"]
+        },
+        "acknowledgement": {
+          "$ref": "#/definitions/licenseAcknowledgementEnumeration"
+        },
+        "text": {
+          "title": "License text",
+          "description": "A way to include the textual content of a license.",
+          "$ref": "#/definitions/attachment"
+        },
+        "url": {
+          "type": "string",
+          "title": "License URL",
+          "description": "The URL to the license file. If specified, a 'license' externalReference should also be specified for completeness",
+          "examples": ["https://www.apache.org/licenses/LICENSE-2.0.txt"],
+          "format": "iri-reference"
+        },
+        "licensing": {"$ref": "#/definitions/licensing"},
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {"$ref": "#/definitions/property"}
+        }
+      }
+    },
+    "licenseAcknowledgementEnumeration": {
+      "title": "License Acknowledgement",
+      "description": "Declared licenses and concluded licenses represent two different stages in the licensing process within software development. Declared licenses refer to the initial intention of the software authors regarding the licensing terms under which their code is released. On the other hand, concluded licenses are the result of a comprehensive analysis of the project's codebase to identify and confirm the actual licenses of the components used, which may differ from the initially declared licenses. While declared licenses provide an upfront indication of the licensing intentions, concluded licenses offer a more thorough understanding of the actual licensing within a project, facilitating proper compliance and risk management. Observed licenses are defined in `@.evidence.licenses`. Observed licenses form the evidence necessary to substantiate a concluded license.",
+      "type": "string",
+      "enum": [
+        "declared",
+        "concluded"
+      ],
+      "meta:enum": {
+        "declared": "Declared licenses represent the initial intentions of authors regarding the licensing terms of their code.",
+        "concluded": "Concluded licenses are verified and confirmed."
+      }
+    },
+    "licenseChoice": {
+      "title": "License Choice",
+      "description": "A list of SPDX licenses and/or named licenses and/or SPDX License Expression.",
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "License",
+            "required": [
+              "license"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "license": {
+                "$ref": "#/definitions/license"
+              }
+            }
+          },
+          {
+            "title": "License Expression",
+            "description": "Specifies the details and attributes related to a software license.\nIt must be a valid SPDX license expression, along with additional properties such as license acknowledgment.",
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "expression"
+            ],
+            "properties": {
+              "expression": {
+                "type": "string",
+                "title": "SPDX License Expression",
+                "description": "A valid SPDX license expression.\nRefer to https://spdx.org/specifications for syntax requirements.",
+                "examples": [
+                  "Apache-2.0 AND (MIT OR GPL-2.0-only)",
+                  "GPL-3.0-only WITH Classpath-exception-2.0"
+                ]
+              },
+              "expressionDetails": {
+                "title": "Expression Details",
+                "description": "Details for parts of the `expression`.",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "description": "This document specifies the details and attributes related to a software license identifier. An SPDX expression may be a compound of license identifiers.\nThe `license_identifier` property serves as the key that identifies each record. Note that this key is not required to be unique, as the same license identifier could apply to multiple, different but similar license details, texts, etc.",
+                  "required": [
+                    "licenseIdentifier"
+                  ],
+                  "properties": {
+                    "licenseIdentifier": {
+                      "title": "License Identifier",
+                      "description": "The valid SPDX license identifier. Refer to https://spdx.org/specifications for syntax requirements.\nThis property serves as the primary key, which uniquely identifies each record.",
+                      "type": "string",
+                      "examples": [
+                        "Apache-2.0",
+                        "GPL-3.0-only WITH Classpath-exception-2.0",
+                        "LicenseRef-my-custom-license"
+                      ]
+                    },
+                    "bom-ref": {
+                      "$ref": "#/definitions/refType",
+                      "title": "BOM Reference",
+                      "description": "An identifier which can be used to reference the license elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+                    },
+                    "text": {
+                      "title": "License texts",
+                      "description": "A way to include the textual content of the license.",
+                      "$ref": "#/definitions/attachment"
+                    },
+                    "url": {
+                      "type": "string",
+                      "title": "License URL",
+                      "description": "The URL to the license file. If specified, a 'license' externalReference should also be specified for completeness",
+                      "examples": [
+                        "https://www.apache.org/licenses/LICENSE-2.0.txt"
+                      ],
+                      "format": "iri-reference"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "acknowledgement": {
+                "$ref": "#/definitions/licenseAcknowledgementEnumeration"
+              },
+              "bom-ref": {
+                "$ref": "#/definitions/refType",
+                "title": "BOM Reference",
+                "description": "An identifier which can be used to reference the license elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+              },
+              "licensing": {
+                "$ref": "#/definitions/licensing"
+              },
+              "properties": {
+                "type": "array",
+                "title": "Properties",
+                "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+                "items": {
+                  "$ref": "#/definitions/property"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "commit": {
+      "type": "object",
+      "title": "Commit",
+      "description": "Specifies an individual commit",
+      "additionalProperties": false,
+      "properties": {
+        "uid": {
+          "type": "string",
+          "title": "UID",
+          "description": "A unique identifier of the commit. This may be version control specific. For example, Subversion uses revision numbers whereas git uses commit hashes."
+        },
+        "url": {
+          "type": "string",
+          "title": "URL",
+          "description": "The URL to the commit. This URL will typically point to a commit in a version control system.",
+          "format": "iri-reference"
+        },
+        "author": {
+          "title": "Author",
+          "description": "The author who created the changes in the commit",
+          "$ref": "#/definitions/identifiableAction"
+        },
+        "committer": {
+          "title": "Committer",
+          "description": "The person who committed or pushed the commit",
+          "$ref": "#/definitions/identifiableAction"
+        },
+        "message": {
+          "type": "string",
+          "title": "Message",
+          "description": "The text description of the contents of the commit"
+        }
+      }
+    },
+    "patch": {
+      "type": "object",
+      "title": "Patch",
+      "description": "Specifies an individual patch",
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "unofficial",
+            "monkey",
+            "backport",
+            "cherry-pick"
+          ],
+          "meta:enum": {
+            "unofficial": "A patch which is not developed by the creators or maintainers of the software being patched. Refer to [https://en.wikipedia.org/wiki/Unofficial_patch](https://en.wikipedia.org/wiki/Unofficial_patch).",
+            "monkey": "A patch which dynamically modifies runtime behavior. Refer to [https://en.wikipedia.org/wiki/Monkey_patch](https://en.wikipedia.org/wiki/Monkey_patch).",
+            "backport": "A patch which takes code from a newer version of the software and applies it to older versions of the same software. Refer to [https://en.wikipedia.org/wiki/Backporting](https://en.wikipedia.org/wiki/Backporting).",
+            "cherry-pick": "A patch created by selectively applying commits from other versions or branches of the same software."
+          },
+          "title": "Patch Type",
+          "description": "Specifies the purpose for the patch including the resolution of defects, security issues, or new behavior or functionality."
+        },
+        "diff": {
+          "title": "Diff",
+          "description": "The patch file (or diff) that shows changes. Refer to [https://en.wikipedia.org/wiki/Diff](https://en.wikipedia.org/wiki/Diff)",
+          "$ref": "#/definitions/diff"
+        },
+        "resolves": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/issue"},
+          "title": "Resolves",
+          "description": "A collection of issues the patch resolves"
+        }
+      }
+    },
+    "diff": {
+      "type": "object",
+      "title": "Diff",
+      "description": "The patch file (or diff) that shows changes. Refer to https://en.wikipedia.org/wiki/Diff",
+      "additionalProperties": false,
+      "properties": {
+        "text": {
+          "title": "Diff text",
+          "description": "Specifies the text of the diff",
+          "$ref": "#/definitions/attachment"
+        },
+        "url": {
+          "type": "string",
+          "title": "URL",
+          "description": "Specifies the URL to the diff",
+          "format": "iri-reference"
+        }
+      }
+    },
+    "issue": {
+      "type": "object",
+      "title": "Issue",
+      "description": "An individual issue that has been resolved.",
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "defect",
+            "enhancement",
+            "security"
+          ],
+          "meta:enum": {
+            "defect": "A fault, flaw, or bug in software.",
+            "enhancement": "A new feature or behavior in software.",
+            "security": "A special type of defect which impacts security."
+          },
+          "title": "Issue Type",
+          "description": "Specifies the type of issue"
+        },
+        "id": {
+          "type": "string",
+          "title": "Issue ID",
+          "description": "The identifier of the issue assigned by the source of the issue"
+        },
+        "name": {
+          "type": "string",
+          "title": "Issue Name",
+          "description": "The name of the issue"
+        },
+        "description": {
+          "type": "string",
+          "title": "Issue Description",
+          "description": "A description of the issue"
+        },
+        "source": {
+          "type": "object",
+          "title": "Source",
+          "description": "The source of the issue where it is documented",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "The name of the source.",
+              "examples": [
+                "National Vulnerability Database",
+                "NVD",
+                "Apache"
+              ]
+            },
+            "url": {
+              "type": "string",
+              "title": "URL",
+              "description": "The url of the issue documentation as provided by the source",
+              "format": "iri-reference"
+            }
+          }
+        },
+        "references": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "iri-reference"
+          },
+          "title": "References",
+          "description": "A collection of URL's for reference. Multiple URLs are allowed.",
+          "examples": ["https://example.com"]
+        }
+      }
+    },
+    "identifiableAction": {
+      "type": "object",
+      "title": "Identifiable Action",
+      "description": "Specifies an individual commit",
+      "additionalProperties": false,
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Timestamp",
+          "description": "The timestamp in which the action occurred"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the individual who performed the action"
+        },
+        "email": {
+          "type": "string",
+          "format": "idn-email",
+          "title": "E-mail",
+          "description": "The email address of the individual who performed the action"
+        }
+      }
+    },
+    "externalReference": {
+      "type": "object",
+      "title": "External Reference",
+      "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM.",
+      "required": [
+        "url",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "anyOf": [
+            {
+              "title": "URL",
+              "type": "string",
+              "format": "iri-reference"
+            },
+            {
+              "title": "BOM-Link",
+              "$ref": "#/definitions/bomLink"
+            }
+          ],
+          "title": "URL",
+          "description": "The URI (URL or URN) to the external reference. External references are URIs and therefore can accept any URL scheme including https ([RFC-7230](https://www.ietf.org/rfc/rfc7230.txt)), mailto ([RFC-2368](https://www.ietf.org/rfc/rfc2368.txt)), tel ([RFC-3966](https://www.ietf.org/rfc/rfc3966.txt)), and dns ([RFC-4501](https://www.ietf.org/rfc/rfc4501.txt)). External references may also include formally registered URNs such as [CycloneDX BOM-Link](https://cyclonedx.org/capabilities/bomlink/) to reference CycloneDX BOMs or any object within a BOM. BOM-Link transforms applicable external references into relationships that can be expressed in a BOM or across BOMs."
+        },
+        "comment": {
+          "type": "string",
+          "title": "Comment",
+          "description": "A comment describing the external reference"
+        },
+        "type": {
+          "type": "string",
+          "title": "Type",
+          "description": "Specifies the type of external reference.",
+          "enum": [
+            "vcs",
+            "issue-tracker",
+            "website",
+            "advisories",
+            "bom",
+            "mailing-list",
+            "social",
+            "chat",
+            "documentation",
+            "support",
+            "source-distribution",
+            "distribution",
+            "distribution-intake",
+            "license",
+            "build-meta",
+            "build-system",
+            "release-notes",
+            "security-contact",
+            "model-card",
+            "log",
+            "configuration",
+            "evidence",
+            "formulation",
+            "attestation",
+            "threat-model",
+            "adversary-model",
+            "risk-assessment",
+            "vulnerability-assertion",
+            "exploitability-statement",
+            "pentest-report",
+            "static-analysis-report",
+            "dynamic-analysis-report",
+            "runtime-analysis-report",
+            "component-analysis-report",
+            "maturity-report",
+            "certification-report",
+            "codified-infrastructure",
+            "quality-metrics",
+            "poam",
+            "electronic-signature",
+            "digital-signature",
+            "rfc-9116",
+            "patent",
+            "patent-family",
+            "patent-assertion",
+            "citation",
+            "other"
+          ],
+          "meta:enum": {
+            "vcs": "Version Control System",
+            "issue-tracker": "Issue or defect tracking system, or an Application Lifecycle Management (ALM) system",
+            "website": "Website",
+            "advisories": "Security advisories",
+            "bom": "Bill of Materials (SBOM, OBOM, HBOM, SaaSBOM, etc)",
+            "mailing-list": "Mailing list or discussion group",
+            "social": "Social media account",
+            "chat": "Real-time chat platform",
+            "documentation": "Documentation, guides, or how-to instructions",
+            "support": "Community or commercial support",
+            "source-distribution": "The location where the source code distributable can be obtained. This is often an archive format such as zip or tgz. The source-distribution type complements use of the version control (vcs) type.",
+            "distribution": "Direct or repository download location",
+            "distribution-intake": "The location where a component was published to. This is often the same as \"distribution\" but may also include specialized publishing processes that act as an intermediary.",
+            "license": "The reference to the license file. If a license URL has been defined in the license node, it should also be defined as an external reference for completeness.",
+            "build-meta": "Build-system specific meta file (i.e. pom.xml, package.json, .nuspec, etc)",
+            "build-system": "Reference to an automated build system",
+            "release-notes": "Reference to release notes",
+            "security-contact": "Specifies a way to contact the maintainer, supplier, or provider in the event of a security incident. Common URIs include links to a disclosure procedure, a mailto (RFC-2368) that specifies an email address, a tel (RFC-3966) that specifies a phone number, or dns (RFC-4501) that specifies the records containing DNS Security TXT.",
+            "model-card": "A model card describes the intended uses of a machine learning model, potential limitations, biases, ethical considerations, training parameters, datasets used to train the model, performance metrics, and other relevant data useful for ML transparency.",
+            "log": "A record of events that occurred in a computer system or application, such as problems, errors, or information on current operations.",
+            "configuration": "Parameters or settings that may be used by other components or services.",
+            "evidence": "Information used to substantiate a claim.",
+            "formulation": "Describes the formulation of any referencable object within the BOM, including components, services, metadata, declarations, or the BOM itself.",
+            "attestation": "Human or machine-readable statements containing facts, evidence, or testimony.",
+            "threat-model": "An enumeration of identified weaknesses, threats, and countermeasures, dataflow diagram (DFD), attack tree, and other supporting documentation in human-readable or machine-readable format.",
+            "adversary-model": "The defined assumptions, goals, and capabilities of an adversary.",
+            "risk-assessment": "Identifies and analyzes the potential of future events that may negatively impact individuals, assets, and/or the environment. Risk assessments may also include judgments on the tolerability of each risk.",
+            "vulnerability-assertion": "A Vulnerability Disclosure Report (VDR) which asserts the known and previously unknown vulnerabilities that affect a component, service, or product including the analysis and findings describing the impact (or lack of impact) that the reported vulnerability has on a component, service, or product.",
+            "exploitability-statement": "A Vulnerability Exploitability eXchange (VEX) which asserts the known vulnerabilities that do not affect a product, product family, or organization, and optionally the ones that do. The VEX should include the analysis and findings describing the impact (or lack of impact) that the reported vulnerability has on the product, product family, or organization.",
+            "pentest-report": "Results from an authorized simulated cyberattack on a component or service, otherwise known as a penetration test.",
+            "static-analysis-report": "SARIF or proprietary machine or human-readable report for which static analysis has identified code quality, security, and other potential issues with the source code.",
+            "dynamic-analysis-report": "Dynamic analysis report that has identified issues such as vulnerabilities and misconfigurations.",
+            "runtime-analysis-report": "Report generated by analyzing the call stack of a running application.",
+            "component-analysis-report": "Report generated by Software Composition Analysis (SCA), container analysis, or other forms of component analysis.",
+            "maturity-report": "Report containing a formal assessment of an organization, business unit, or team against a maturity model.",
+            "certification-report": "Industry, regulatory, or other certification from an accredited (if applicable) certification body.",
+            "codified-infrastructure": "Code or configuration that defines and provisions virtualized infrastructure, commonly referred to as Infrastructure as Code (IaC).",
+            "quality-metrics": "Report or system in which quality metrics can be obtained.",
+            "poam": "Plans of Action and Milestones (POA&M) complement an \"attestation\" external reference. POA&M is defined by NIST as a \"document that identifies tasks needing to be accomplished. It details resources required to accomplish the elements of the plan, any milestones in meeting the tasks and scheduled completion dates for the milestones\".",
+            "electronic-signature": "An e-signature is commonly a scanned representation of a written signature or a stylized script of the person's name.",
+            "digital-signature": "A signature that leverages cryptography, typically public/private key pairs, which provides strong authenticity verification.",
+            "rfc-9116": "Document that complies with [RFC 9116](https://www.ietf.org/rfc/rfc9116.html) (A File Format to Aid in Security Vulnerability Disclosure)",
+            "patent": "References information about patents which may be defined in human-readable documents or in machine-readable formats such as CycloneDX or ST.96. For detailed patent information or to reference the information provided directly by patent offices, it is recommended to leverage standards from the World Intellectual Property Organization (WIPO) such as [ST.96](https://www.wipo.int/standards/en/st96).",
+            "patent-family": "References information about a patent family which may be defined in human-readable documents or in machine-readable formats such as CycloneDX or ST.96. A patent family is a group of related patent applications or granted patents that cover the same or similar invention. For detailed patent family information or to reference the information provided directly by patent offices, it is recommended to leverage standards from the World Intellectual Property Organization (WIPO) such as [ST.96](https://www.wipo.int/standards/en/st96).",
+            "patent-assertion" : "References assertions made regarding patents associated with a component or service. Assertions distinguish between ownership, licensing, and other relevant interactions with patents.",
+            "citation": "A reference to external citations applicable to the object identified by this BOM entry or the BOM itself. When used with a BOM-Link, this allows offloading citations into a separate CycloneDX BOM.",
+            "other": "Use this if no other types accurately describe the purpose of the external reference."
+          }
+        },
+        "hashes": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/hash"},
+          "title": "Hashes",
+          "description": "The hashes of the external reference (if applicable)."
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {"$ref": "#/definitions/property"}
+        }
+      }
+    },
+    "dependency": {
+      "type": "object",
+      "title": "Dependency",
+      "description": "Defines the direct dependencies of a component, service, or the components provided/implemented by a given component. Components or services that do not have their own dependencies must be declared as empty elements within the graph. Components or services that are not represented in the dependency graph may have unknown dependencies. It is recommended that implementations assume this to be opaque and not an indicator of an object being dependency-free. It is recommended to leverage compositions to indicate unknown dependency graphs.",
+      "required": [
+        "ref"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "ref": {
+          "$ref": "#/definitions/refLinkType",
+          "title": "Reference",
+          "description": "References a component or service by its bom-ref attribute"
+        },
+        "dependsOn": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/refLinkType"
+          },
+          "title": "Depends On",
+          "description": "The bom-ref identifiers of the components or services that are dependencies of this dependency object."
+        },
+        "provides": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/refLinkType"
+          },
+          "title": "Provides",
+          "description": "The bom-ref identifiers of the components or services that define a given specification or standard, which are provided or implemented by this dependency object.\nFor example, a cryptographic library which implements a cryptographic algorithm. A component which implements another component does not imply that the implementation is in use."
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "title": "Service",
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the service elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+        },
+        "provider": {
+          "title": "Provider",
+          "description": "The organization that provides the service.",
+          "$ref": "#/definitions/organizationalEntity"
+        },
+        "group": {
+          "type": "string",
+          "title": "Service Group",
+          "description": "The grouping name, namespace, or identifier. This will often be a shortened, single name of the company or project that produced the service or domain name. Whitespace and special characters should be avoided.",
+          "examples": ["com.acme"]
+        },
+        "name": {
+          "type": "string",
+          "title": "Service Name",
+          "description": "The name of the service. This will often be a shortened, single name of the service.",
+          "examples": ["ticker-service"]
+        },
+        "version": {
+          "$ref": "#/definitions/version",
+          "title": "Service Version",
+          "description": "The service version."
+        },
+        "description": {
+          "type": "string",
+          "title": "Service Description",
+          "description": "Specifies a description for the service"
+        },
+        "endpoints": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "iri-reference"
+          },
+          "title": "Endpoints",
+          "description": "The endpoint URIs of the service. Multiple endpoints are allowed.",
+          "examples": ["https://example.com/api/v1/ticker"]
+        },
+        "authenticated": {
+          "type": "boolean",
+          "title": "Authentication Required",
+          "description": "A boolean value indicating if the service requires authentication. A value of true indicates the service requires authentication prior to use. A value of false indicates the service does not require authentication."
+        },
+        "x-trust-boundary": {
+          "type": "boolean",
+          "title": "Crosses Trust Boundary",
+          "description": "A boolean value indicating if use of the service crosses a trust zone or boundary. A value of true indicates that by using the service, a trust boundary is crossed. A value of false indicates that by using the service, a trust boundary is not crossed."
+        },
+        "trustZone": {
+          "type": "string",
+          "title": "Trust Zone",
+          "description": "The name of the trust zone the service resides in."
+        },
+        "data": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/serviceData"},
+          "title": "Data",
+          "description": "Specifies information about the data including the directional flow of data and the data classification."
+        },
+        "licenses": {
+          "$ref": "#/definitions/licenseChoice",
+          "title": "Service License(s)"
+        },
+        "patentAssertions": {
+          "$ref": "#/definitions/patentAssertions",
+          "title": "Service Patent(s)"
+        },
+        "externalReferences": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/externalReference"},
+          "title": "External References",
+          "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+        },
+        "services": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/service"},
+          "uniqueItems": true,
+          "title": "Services",
+          "description": "A list of services included or deployed behind the parent service. This is not a dependency tree. It provides a way to specify a hierarchical representation of service assemblies."
+        },
+        "releaseNotes": {
+          "$ref": "#/definitions/releaseNotes",
+          "title": "Release notes",
+          "description": "Specifies release notes."
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {"$ref": "#/definitions/property"}
+        },
+        "tags": {
+          "$ref": "#/definitions/tags",
+          "title": "Tags"
+        },
+        "signature": {
+          "$ref": "#/definitions/signature",
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+        }
+      }
+    },
+    "serviceData": {
+      "type": "object",
+      "title": "Hash Objects",
+      "required": [
+        "flow",
+        "classification"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "flow": {
+          "$ref": "#/definitions/dataFlowDirection",
+          "title": "Directional Flow",
+          "description": "Specifies the flow direction of the data. Direction is relative to the service. Inbound flow states that data enters the service. Outbound flow states that data leaves the service. Bi-directional states that data flows both ways and unknown states that the direction is not known."
+        },
+        "classification": {
+          "$ref": "#/definitions/dataClassification"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "Name for the defined data",
+          "examples": [
+            "Credit card reporting"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Short description of the data content and usage",
+          "examples": [
+            "Credit card information being exchanged in between the web app and the database"
+          ]
+        },
+        "governance": {
+          "title": "Data Governance",
+          "$ref": "#/definitions/dataGovernance"
+        },
+        "source": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "title": "URL",
+                "type": "string",
+                "format": "iri-reference"
+              },
+              {
+                "title": "BOM-Link Element",
+                "$ref": "#/definitions/bomLinkElementType"
+              }
+            ]
+          },
+          "title": "Source",
+          "description": "The URI, URL, or BOM-Link of the components or services the data came in from"
+        },
+        "destination": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "title": "URL",
+                "type": "string",
+                "format": "iri-reference"
+              },
+              {
+                "title": "BOM-Link Element",
+                "$ref": "#/definitions/bomLinkElementType"
+              }
+            ]
+          },
+          "title": "Destination",
+          "description": "The URI, URL, or BOM-Link of the components or services the data is sent to"
+        }
+      }
+    },
+    "dataFlowDirection": {
+      "type": "string",
+      "enum": [
+        "inbound",
+        "outbound",
+        "bi-directional",
+        "unknown"
+      ],
+      "meta:enum": {
+        "inbound": "Data that enters a service.",
+        "outbound": "Data that exits a service.",
+        "bi-directional": "Data flows in and out of the service.",
+        "unknown": "The directional flow of data is not known."
+      },
+      "title": "Data flow direction",
+      "description": "Specifies the flow direction of the data. Direction is relative to the service."
+    },
+    "copyright": {
+      "type": "object",
+      "title": "Copyright",
+      "description": "A copyright notice informing users of the underlying claims to copyright ownership in a published work.",
+      "required": [
+        "text"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "text": {
+          "type": "string",
+          "title": "Copyright Text",
+          "description": "The textual content of the copyright."
+        }
+      }
+    },
+    "componentEvidence": {
+      "type": "object",
+      "title": "Evidence",
+      "description": "Provides the ability to document evidence collected through various forms of extraction or analysis.",
+      "additionalProperties": false,
+      "properties": {
+        "identity": {
+          "title": "Identity Evidence",
+          "description": "Evidence that substantiates the identity of a component. The identity may be an object or an array of identity objects. Support for specifying identity as a single object was introduced in CycloneDX v1.5. Arrays were introduced in v1.6. It is recommended that all implementations use arrays, even if only one identity object is specified.",
+          "oneOf" : [
+            {
+              "type": "array",
+              "title": "Array of Identity Objects",
+              "items": { "$ref": "#/definitions/componentIdentityEvidence" }
+            },
+            {
+              "title": "A Single Identity Object",
+              "description": "[Deprecated]",
+              "$ref": "#/definitions/componentIdentityEvidence",
+              "deprecated": true
+            }
+          ]
+        },
+        "occurrences": {
+          "type": "array",
+          "title": "Occurrences",
+          "description": "Evidence of individual instances of a component spread across multiple locations.",
+          "items": {
+            "type": "object",
+            "required": [ "location" ],
+            "additionalProperties": false,
+            "properties": {
+              "bom-ref": {
+                "$ref": "#/definitions/refType",
+                "title": "BOM Reference",
+                "description": "An identifier which can be used to reference the occurrence elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+              },
+              "location": {
+                "type": "string",
+                "title": "Location",
+                "description": "The location or path to where the component was found."
+              },
+              "line": {
+                "type": "integer",
+                "minimum": 0,
+                "title": "Line Number",
+                "description": "The line number where the component was found."
+              },
+              "offset": {
+                "type": "integer",
+                "minimum": 0,
+                "title": "Offset",
+                "description": "The offset where the component was found."
+              },
+              "symbol": {
+                "type": "string",
+                "title": "Symbol",
+                "description": "The symbol name that was found associated with the component."
+              },
+              "additionalContext": {
+                "type": "string",
+                "title": "Additional Context",
+                "description": "Any additional context of the detected component (e.g. a code snippet)."
+              }
+            }
+          }
+        },
+        "callstack": {
+          "type": "object",
+          "title": "Call Stack",
+          "description": "Evidence of the components use through the callstack.",
+          "additionalProperties": false,
+          "properties": {
+            "frames": {
+              "type": "array",
+              "title": "Frames",
+              "description": "Within a call stack, a frame is a discrete unit that encapsulates an execution context, including local variables, parameters, and the return address. As function calls are made, frames are pushed onto the stack, forming an array-like structure that orchestrates the flow of program execution and manages the sequence of function invocations.",
+              "items": {
+                "type": "object",
+                "required": [
+                  "module"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "package": {
+                    "title": "Package",
+                    "description": "A package organizes modules into namespaces, providing a unique namespace for each type it contains.",
+                    "type": "string"
+                  },
+                  "module": {
+                    "title": "Module",
+                    "description": "A module or class that encloses functions/methods and other code.",
+                    "type": "string"
+                  },
+                  "function": {
+                    "title": "Function",
+                    "description": "A block of code designed to perform a particular task.",
+                    "type": "string"
+                  },
+                  "parameters": {
+                    "title": "Parameters",
+                    "description": "Arguments that are passed to the module or function.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "line": {
+                    "title": "Line",
+                    "description": "The line number the code that is called resides on.",
+                    "type": "integer"
+                  },
+                  "column": {
+                    "title": "Column",
+                    "description": "The column the code that is called resides.",
+                    "type": "integer"
+                  },
+                  "fullFilename": {
+                    "title": "Full Filename",
+                    "description": "The full path and filename of the module.",
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "licenses": {
+          "$ref": "#/definitions/licenseChoice",
+          "title": "License Evidence"
+        },
+        "copyright": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/copyright"},
+          "title": "Copyright Evidence",
+          "description": "Copyright evidence captures intellectual property assertions, providing evidence of possible ownership and legal protection."
+        }
+      }
+    },
+    "compositions": {
+      "type": "object",
+      "title": "Compositions",
+      "required": [
+        "aggregate"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the composition elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+        },
+        "aggregate": {
+          "$ref": "#/definitions/aggregateType",
+          "title": "Aggregate",
+          "description": "Specifies an aggregate type that describes how complete a relationship is."
+        },
+        "assemblies": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "anyOf": [
+              {
+                "title": "Ref",
+                "$ref": "#/definitions/refLinkType"
+              },
+              {
+                "title": "BOM-Link Element",
+                "$ref": "#/definitions/bomLinkElementType"
+              }
+            ]
+          },
+          "title": "BOM references",
+          "description": "The bom-ref identifiers of the components or services being described. Assemblies refer to nested relationships whereby a constituent part may include other constituent parts. References do not cascade to child parts. References are explicit for the specified constituent part only."
+        },
+        "dependencies": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "title": "BOM references",
+          "description": "The bom-ref identifiers of the components or services being described. Dependencies refer to a relationship whereby an independent constituent part requires another independent constituent part. References do not cascade to transitive dependencies. References are explicit for the specified dependency only."
+        },
+        "vulnerabilities": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "title": "BOM references",
+          "description": "The bom-ref identifiers of the vulnerabilities being described."
+        },
+        "signature": {
+          "$ref": "#/definitions/signature",
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+        }
+      }
+    },
+    "aggregateType": {
+      "type": "string",
+      "default": "not_specified",
+      "enum": [
+        "complete",
+        "incomplete",
+        "incomplete_first_party_only",
+        "incomplete_first_party_proprietary_only",
+        "incomplete_first_party_opensource_only",
+        "incomplete_third_party_only",
+        "incomplete_third_party_proprietary_only",
+        "incomplete_third_party_opensource_only",
+        "unknown",
+        "not_specified"
+      ],
+      "meta:enum": {
+        "complete": "The relationship is complete. No further relationships including constituent components, services, or dependencies are known to exist.",
+        "incomplete": "The relationship is incomplete. Additional relationships exist and may include constituent components, services, or dependencies.",
+        "incomplete_first_party_only": "The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented.",
+        "incomplete_first_party_proprietary_only": "The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented, limited specifically to those that are proprietary.",
+        "incomplete_first_party_opensource_only": "The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented, limited specifically to those that are opensource.",
+        "incomplete_third_party_only": "The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented.",
+        "incomplete_third_party_proprietary_only": "The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented, limited specifically to those that are proprietary.",
+        "incomplete_third_party_opensource_only": "The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented, limited specifically to those that are opensource.",
+        "unknown": "The relationship may be complete or incomplete. This usually signifies a 'best-effort' to obtain constituent components, services, or dependencies but the completeness is inconclusive.",
+        "not_specified": "The relationship completeness is not specified."
+      }
+    },
+    "property": {
+      "type": "object",
+      "title": "Lightweight name-value pair",
+      "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the property. Duplicate names are allowed, each potentially having a different value."
+        },
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The value of the property."
+        }
+      }
+    },
+    "localeType": {
+      "type": "string",
+      "pattern": "^([a-z]{2})(-[A-Z]{2})?$",
+      "title": "Locale",
+      "description": "Defines a syntax for representing two character language code (ISO-639) followed by an optional two character country code. The language code must be lower case. If the country code is specified, the country code must be upper case. The language code and country code must be separated by a minus sign. Examples: en, en-US, fr, fr-CA"
+    },
+    "releaseType": {
+      "type": "string",
+      "examples": [
+        "major",
+        "minor",
+        "patch",
+        "pre-release",
+        "internal"
+      ],
+      "description": "The software versioning type. It is recommended that the release type use one of 'major', 'minor', 'patch', 'pre-release', or 'internal'. Representing all possible software release types is not practical, so standardizing on the recommended values, whenever possible, is strongly encouraged.\n\n* __major__ = A major release may contain significant changes or may introduce breaking changes.\n* __minor__ = A minor release, also known as an update, may contain a smaller number of changes than major releases.\n* __patch__ = Patch releases are typically unplanned and may resolve defects or important security issues.\n* __pre-release__ = A pre-release may include alpha, beta, or release candidates and typically have limited support. They provide the ability to preview a release prior to its general availability.\n* __internal__ = Internal releases are not for public consumption and are intended to be used exclusively by the project or manufacturer that produced it."
+    },
+    "note": {
+      "type": "object",
+      "title": "Note",
+      "description": "A note containing the locale and content.",
+      "required": [
+        "text"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "locale": {
+          "$ref": "#/definitions/localeType",
+          "title": "Locale",
+          "description": "The ISO-639 (or higher) language code and optional ISO-3166 (or higher) country code. Examples include: \"en\", \"en-US\", \"fr\" and \"fr-CA\""
+        },
+        "text": {
+          "title": "Release note content",
+          "description": "Specifies the full content of the release note.",
+          "$ref": "#/definitions/attachment"
+        }
+      }
+    },
+    "releaseNotes": {
+      "type": "object",
+      "title": "Release notes",
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/releaseType",
+          "title": "Type",
+          "description": "The software versioning type the release note describes."
+        },
+        "title": {
+          "type": "string",
+          "title": "Title",
+          "description": "The title of the release."
+        },
+        "featuredImage": {
+          "type": "string",
+          "format": "iri-reference",
+          "title": "Featured image",
+          "description": "The URL to an image that may be prominently displayed with the release note."
+        },
+        "socialImage": {
+          "type": "string",
+          "format": "iri-reference",
+          "title": "Social image",
+          "description": "The URL to an image that may be used in messaging on social media platforms."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A short description of the release."
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Timestamp",
+          "description": "The date and time (timestamp) when the release note was created."
+        },
+        "aliases": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "Aliases",
+          "description": "One or more alternate names the release may be referred to. This may include unofficial terms used by development and marketing teams (e.g. code names)."
+        },
+        "tags": {
+          "$ref": "#/definitions/tags",
+          "title": "Tags"
+        },
+        "resolves": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/issue"},
+          "title": "Resolves",
+          "description": "A collection of issues that have been resolved."
+        },
+        "notes": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/note"},
+          "title": "Notes",
+          "description": "Zero or more release notes containing the locale and content. Multiple note objects may be specified to support release notes in a wide variety of languages."
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {"$ref": "#/definitions/property"}
+        }
+      }
+    },
+    "advisory": {
+      "type": "object",
+      "title": "Advisory",
+      "description": "Title and location where advisory information can be obtained. An advisory is a notification of a threat to a component, service, or system.",
+      "required": ["url"],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string",
+          "title": "Title",
+          "description": "A name of the advisory."
+        },
+        "url": {
+          "type": "string",
+          "title": "URL",
+          "format": "iri-reference",
+          "description": "Location where the advisory can be obtained."
+        }
+      }
+    },
+    "cwe": {
+      "type": "integer",
+      "minimum": 1,
+      "title": "CWE",
+      "description": "Integer representation of a Common Weaknesses Enumerations (CWE). For example 399 (of https://cwe.mitre.org/data/definitions/399.html)"
+    },
+    "severity": {
+      "type": "string",
+      "title": "Severity",
+      "description": "Textual representation of the severity of the vulnerability adopted by the analysis method. If the analysis method uses values other than what is provided, the user is expected to translate appropriately.",
+      "enum": [
+        "critical",
+        "high",
+        "medium",
+        "low",
+        "info",
+        "none",
+        "unknown"
+      ],
+      "meta:enum": {
+        "critical": "Critical severity",
+        "high": "High severity",
+        "medium": "Medium severity",
+        "low": "Low severity",
+        "info": "Informational warning.",
+        "none": "None",
+        "unknown": "The severity is not known"
+      }
+    },
+    "scoreMethod": {
+      "type": "string",
+      "title": "Method",
+      "description": "Specifies the severity or risk scoring methodology or standard used.",
+      "enum": [
+        "CVSSv2",
+        "CVSSv3",
+        "CVSSv31",
+        "CVSSv4",
+        "OWASP",
+        "SSVC",
+        "other"
+      ],
+      "meta:enum": {
+        "CVSSv2": "Common Vulnerability Scoring System v2.0",
+        "CVSSv3": "Common Vulnerability Scoring System v3.0",
+        "CVSSv31": "Common Vulnerability Scoring System v3.1",
+        "CVSSv4": "Common Vulnerability Scoring System v4.0",
+        "OWASP": "OWASP Risk Rating Methodology",
+        "SSVC": "Stakeholder Specific Vulnerability Categorization",
+        "other": "Another severity or risk scoring methodology"
+      }
+    },
+    "impactAnalysisState": {
+      "type": "string",
+      "title": "Impact Analysis State",
+      "description": "Declares the current state of an occurrence of a vulnerability, after automated or manual analysis.",
+      "enum": [
+        "resolved",
+        "resolved_with_pedigree",
+        "exploitable",
+        "in_triage",
+        "false_positive",
+        "not_affected"
+      ],
+      "meta:enum": {
+        "resolved": "The vulnerability has been remediated.",
+        "resolved_with_pedigree": "The vulnerability has been remediated and evidence of the changes are provided in the affected components pedigree containing verifiable commit history and/or diff(s).",
+        "exploitable": "The vulnerability may be directly or indirectly exploitable.",
+        "in_triage": "The vulnerability is being investigated.",
+        "false_positive": "The vulnerability is not specific to the component or service and was falsely identified or associated.",
+        "not_affected": "The component or service is not affected by the vulnerability. Justification should be specified for all not_affected cases."
+      }
+    },
+    "impactAnalysisJustification": {
+      "type": "string",
+      "title": "Impact Analysis Justification",
+      "description": "The rationale of why the impact analysis state was asserted.",
+      "enum": [
+        "code_not_present",
+        "code_not_reachable",
+        "requires_configuration",
+        "requires_dependency",
+        "requires_environment",
+        "protected_by_compiler",
+        "protected_at_runtime",
+        "protected_at_perimeter",
+        "protected_by_mitigating_control"
+      ],
+      "meta:enum": {
+        "code_not_present": "The code has been removed or tree-shaked.",
+        "code_not_reachable": "The vulnerable code is not invoked at runtime.",
+        "requires_configuration": "Exploitability requires a configurable option to be set/unset.",
+        "requires_dependency": "Exploitability requires a dependency that is not present.",
+        "requires_environment": "Exploitability requires a certain environment which is not present.",
+        "protected_by_compiler": "Exploitability requires a compiler flag to be set/unset.",
+        "protected_at_runtime": "Exploits are prevented at runtime.",
+        "protected_at_perimeter": "Attacks are blocked at physical, logical, or network perimeter.",
+        "protected_by_mitigating_control": "Preventative measures have been implemented that reduce the likelihood and/or impact of the vulnerability."
+      }
+    },
+    "rating": {
+      "type": "object",
+      "title": "Rating",
+      "description": "Defines the severity or risk ratings of a vulnerability.",
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/vulnerabilitySource",
+          "description": "The source that calculated the severity or risk rating of the vulnerability."
+        },
+        "score": {
+          "type": "number",
+          "title": "Score",
+          "description": "The numerical score of the rating."
+        },
+        "severity": {
+          "$ref": "#/definitions/severity",
+          "description": "Textual representation of the severity that corresponds to the numerical score of the rating."
+        },
+        "method": {
+          "$ref": "#/definitions/scoreMethod"
+        },
+        "vector": {
+          "type": "string",
+          "title": "Vector",
+          "description": "Textual representation of the metric values used to score the vulnerability"
+        },
+        "justification": {
+          "type": "string",
+          "title": "Justification",
+          "description": "A reason for rating the vulnerability as it was"
+        }
+      }
+    },
+    "vulnerabilitySource": {
+      "type": "object",
+      "title": "Source",
+      "description": "The source of vulnerability information. This is often the organization that published the vulnerability.",
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "type": "string",
+          "title": "URL",
+          "description": "The url of the vulnerability documentation as provided by the source.",
+          "examples": [
+            "https://nvd.nist.gov/vuln/detail/CVE-2021-39182"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the source.",
+          "examples": [
+            "NVD",
+            "National Vulnerability Database",
+            "OSS Index",
+            "VulnDB",
+            "GitHub Advisories"
+          ]
+        }
+      }
+    },
+    "vulnerability": {
+      "type": "object",
+      "title": "Vulnerability",
+      "description": "Defines a weakness in a component or service that could be exploited or triggered by a threat source.",
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the vulnerability elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+        },
+        "id": {
+          "type": "string",
+          "title": "ID",
+          "description": "The identifier that uniquely identifies the vulnerability.",
+          "examples": [
+            "CVE-2021-39182",
+            "GHSA-35m5-8cvj-8783",
+            "SNYK-PYTHON-ENROCRYPT-1912876"
+          ]
+        },
+        "source": {
+          "$ref": "#/definitions/vulnerabilitySource",
+          "description": "The source that published the vulnerability."
+        },
+        "references": {
+          "type": "array",
+          "title": "References",
+          "description": "Zero or more pointers to vulnerabilities that are the equivalent of the vulnerability specified. Often times, the same vulnerability may exist in multiple sources of vulnerability intelligence, but have different identifiers. References provide a way to correlate vulnerabilities across multiple sources of vulnerability intelligence.",
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "source"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string",
+                "title": "ID",
+                "description": "An identifier that uniquely identifies the vulnerability.",
+                "examples": [
+                  "CVE-2021-39182",
+                  "GHSA-35m5-8cvj-8783",
+                  "SNYK-PYTHON-ENROCRYPT-1912876"
+                ]
+              },
+              "source": {
+                "$ref": "#/definitions/vulnerabilitySource",
+                "description": "The source that published the vulnerability."
+              }
+            }
+          }
+        },
+        "ratings": {
+          "type": "array",
+          "title": "Ratings",
+          "description": "List of vulnerability ratings",
+          "items": {
+            "$ref": "#/definitions/rating"
+          }
+        },
+        "cwes": {
+          "type": "array",
+          "title": "CWEs",
+          "description": "List of Common Weaknesses Enumerations (CWEs) codes that describes this vulnerability.",
+          "examples": [399],
+          "items": {
+            "$ref": "#/definitions/cwe"
+          }
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A description of the vulnerability as provided by the source."
+        },
+        "detail": {
+          "type": "string",
+          "title": "Details",
+          "description": "If available, an in-depth description of the vulnerability as provided by the source organization. Details often include information useful in understanding root cause."
+        },
+        "recommendation": {
+          "type": "string",
+          "title": "Recommendation",
+          "description": "Recommendations of how the vulnerability can be remediated or mitigated."
+        },
+        "workaround": {
+          "type": "string",
+          "title": "Workarounds",
+          "description": "A bypass, usually temporary, of the vulnerability that reduces its likelihood and/or impact. Workarounds often involve changes to configuration or deployments."
+        },
+        "proofOfConcept": {
+          "type": "object",
+          "title": "Proof of Concept",
+          "description": "Evidence used to reproduce the vulnerability.",
+          "properties": {
+            "reproductionSteps": {
+              "type": "string",
+              "title": "Steps to Reproduce",
+              "description": "Precise steps to reproduce the vulnerability."
+            },
+            "environment": {
+              "type": "string",
+              "title": "Environment",
+              "description": "A description of the environment in which reproduction was possible."
+            },
+            "supportingMaterial": {
+              "type": "array",
+              "title": "Supporting Material",
+              "description": "Supporting material that helps in reproducing or understanding how reproduction is possible. This may include screenshots, payloads, and PoC exploit code.",
+              "items": { "$ref": "#/definitions/attachment" }
+            }
+          }
+        },
+        "advisories": {
+          "type": "array",
+          "title": "Advisories",
+          "description": "Published advisories of the vulnerability if provided.",
+          "items": {
+            "$ref": "#/definitions/advisory"
+          }
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Created",
+          "description": "The date and time (timestamp) when the vulnerability record was created in the vulnerability database."
+        },
+        "published": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Published",
+          "description": "The date and time (timestamp) when the vulnerability record was first published."
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Updated",
+          "description": "The date and time (timestamp) when the vulnerability record was last updated."
+        },
+        "rejected": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Rejected",
+          "description": "The date and time (timestamp) when the vulnerability record was rejected (if applicable)."
+        },
+        "credits": {
+          "type": "object",
+          "title": "Credits",
+          "description": "Individuals or organizations credited with the discovery of the vulnerability.",
+          "additionalProperties": false,
+          "properties": {
+            "organizations": {
+              "type": "array",
+              "title": "Organizations",
+              "description": "The organizations credited with vulnerability discovery.",
+              "items": {
+                "$ref": "#/definitions/organizationalEntity"
+              }
+            },
+            "individuals": {
+              "type": "array",
+              "title": "Individuals",
+              "description": "The individuals, not associated with organizations, that are credited with vulnerability discovery.",
+              "items": {
+                "$ref": "#/definitions/organizationalContact"
+              }
+            }
+          }
+        },
+        "tools": {
+          "title": "Tools",
+          "description": "The tool(s) used to identify, confirm, or score the vulnerability.",
+          "oneOf": [
+            {
+              "type": "object",
+              "title": "Tools",
+              "description": "The tool(s) used to identify, confirm, or score the vulnerability.",
+              "additionalProperties": false,
+              "properties": {
+                "components": {
+                  "type": "array",
+                  "items": {"$ref": "#/definitions/component"},
+                  "uniqueItems": true,
+                  "title": "Components",
+                  "description": "A list of software and hardware components used as tools."
+                },
+                "services": {
+                  "type": "array",
+                  "items": {"$ref": "#/definitions/service"},
+                  "uniqueItems": true,
+                  "title": "Services",
+                  "description": "A list of services used as tools. This may include microservices, function-as-a-service, and other types of network or intra-process services."
+                }
+              }
+            },
+            {
+              "type": "array",
+              "title": "Tools (legacy)",
+              "description": "[Deprecated]\nThe tool(s) used to identify, confirm, or score the vulnerability.",
+              "deprecated": true,
+              "items": {"$ref": "#/definitions/tool"}
+            }
+          ]
+        },
+        "analysis": {
+          "type": "object",
+          "title": "Impact Analysis",
+          "description": "An assessment of the impact and exploitability of the vulnerability.",
+          "additionalProperties": false,
+          "properties": {
+            "state": {
+              "$ref": "#/definitions/impactAnalysisState"
+            },
+            "justification": {
+              "$ref": "#/definitions/impactAnalysisJustification"
+            },
+            "response": {
+              "type": "array",
+              "title": "Response",
+              "description": "A response to the vulnerability by the manufacturer, supplier, or project responsible for the affected component or service. More than one response is allowed. Responses are strongly encouraged for vulnerabilities where the analysis state is exploitable.",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "can_not_fix",
+                  "will_not_fix",
+                  "update",
+                  "rollback",
+                  "workaround_available"
+                ],
+                "meta:enum": {
+                  "can_not_fix": "Can not fix",
+                  "will_not_fix": "Will not fix",
+                  "update": "Update to a different revision or release",
+                  "rollback": "Revert to a previous revision or release",
+                  "workaround_available": "There is a workaround available"
+                }
+              }
+            },
+            "detail": {
+              "type": "string",
+              "title": "Detail",
+              "description": "Detailed description of the impact including methods used during assessment. If a vulnerability is not exploitable, this field should include specific details on why the component or service is not impacted by this vulnerability."
+            },
+            "firstIssued": {
+              "type": "string",
+              "format": "date-time",
+              "title": "First Issued",
+              "description": "The date and time (timestamp) when the analysis was first issued."
+            },
+            "lastUpdated": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Last Updated",
+              "description": "The date and time (timestamp) when the analysis was last updated."
+            }
+          }
+        },
+        "affects": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "required": [
+              "ref"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "ref": {
+                "anyOf": [
+                  {
+                    "title": "Ref",
+                    "$ref": "#/definitions/refLinkType"
+                  },
+                  {
+                    "title": "BOM-Link Element",
+                    "$ref": "#/definitions/bomLinkElementType"
+                  }
+                ],
+                "title": "Reference",
+                "description": "References a component or service by the objects bom-ref"
+              },
+              "versions": {
+                "type": "array",
+                "title": "Versions",
+                "description": "Zero or more individual versions or range of versions.",
+                "items": {
+                  "type": "object",
+                  "oneOf": [
+                    {
+                      "required": ["version"]
+                    },
+                    {
+                      "required": ["range"]
+                    }
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "version": {
+                      "title": "Version",
+                      "description": "A single version of a component or service.",
+                      "$ref": "#/definitions/version"
+                    },
+                    "range": {
+                      "title": "Version Range",
+                      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/vers-spec",
+                      "$ref": "#/definitions/versionRange"
+                    },
+                    "status": {
+                      "title": "Status",
+                      "description": "The vulnerability status for the version or range of versions.",
+                      "$ref": "#/definitions/affectedStatus",
+                      "default": "affected"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "title": "Affects",
+          "description": "The components or services that are affected by the vulnerability."
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "affectedStatus": {
+      "description": "The vulnerability status of a given version or range of versions of a product. The statuses 'affected' and 'unaffected' indicate that the version is affected or unaffected by the vulnerability. The status 'unknown' indicates that it is unknown or unspecified whether the given version is affected. There can be many reasons for an 'unknown' status, including that an investigation has not been undertaken or that a vendor has not disclosed the status.",
+      "type": "string",
+      "enum": [
+        "affected",
+        "unaffected",
+        "unknown"
+      ],
+      "meta:enum": {
+        "affected": "The version is affected by the vulnerability.",
+        "unaffected": "The version is not affected by the vulnerability.",
+        "unknown": "It is unknown (or unspecified) whether the given version is affected."
+      }
+    },
+    "version": {
+      "description": "A single disjunctive version identifier, for a component or service.",
+      "type": "string",
+      "maxLength": 1024,
+      "examples": [
+        "9.0.14",
+        "v1.33.7",
+        "7.0.0-M1",
+        "2.0pre1",
+        "1.0.0-beta1",
+        "0.8.15"
+      ]
+    },
+    "versionRange": {
+      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/vers-spec",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 4096,
+      "examples": [
+        "vers:cargo/9.0.14",
+        "vers:npm/1.2.3|>=2.0.0|<5.0.0",
+        "vers:pypi/0.0.0|0.0.1|0.0.2|0.0.3|1.0|2.0pre1",
+        "vers:tomee/>=1.0.0-beta1|<=1.7.5|>=7.0.0-M1|<=7.0.7|>=7.1.0|<=7.1.2|>=8.0.0-M1|<=8.0.1",
+        "vers:gem/>=2.2.0|!= 2.2.1|<2.3.0"
+      ]
+    },
+    "range": {
+      "deprecated": true,
+      "description": "Deprecated definition. use definition `versionRange` instead.",
+      "$ref": "#/definitions/versionRange"
+    },
+    "annotations": {
+      "type": "object",
+      "title": "Annotations",
+      "description": "A comment, note, explanation, or similar textual content which provides additional context to the object(s) being annotated.",
+      "required": [
+        "subjects",
+        "annotator",
+        "timestamp",
+        "text"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the annotation elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+        },
+        "subjects": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "anyOf": [
+              {
+                "title": "Ref",
+                "$ref": "#/definitions/refLinkType"
+              },
+              {
+                "title": "BOM-Link Element",
+                "$ref": "#/definitions/bomLinkElementType"
+              }
+            ]
+          },
+          "title": "Subjects",
+          "description": "The object in the BOM identified by its bom-ref. This is often a component or service, but may be any object type supporting bom-refs."
+        },
+        "annotator": {
+          "type": "object",
+          "title": "Annotator",
+          "description": "The organization, person, component, or service which created the textual content of the annotation.",
+          "oneOf": [
+            {
+              "required": [
+                "organization"
+              ]
+            },
+            {
+              "required": [
+                "individual"
+              ]
+            },
+            {
+              "required": [
+                "component"
+              ]
+            },
+            {
+              "required": [
+                "service"
+              ]
+            }
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "organization": {
+              "description": "The organization that created the annotation",
+              "$ref": "#/definitions/organizationalEntity"
+            },
+            "individual": {
+              "description": "The person that created the annotation",
+              "$ref": "#/definitions/organizationalContact"
+            },
+            "component": {
+              "description": "The tool or component that created the annotation",
+              "$ref": "#/definitions/component"
+            },
+            "service": {
+              "description": "The service that created the annotation",
+              "$ref": "#/definitions/service"
+            }
+          }
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Timestamp",
+          "description": "The date and time (timestamp) when the annotation was created."
+        },
+        "text": {
+          "type": "string",
+          "title": "Text",
+          "description": "The textual content of the annotation."
+        },
+        "signature": {
+          "$ref": "#/definitions/signature",
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+        }
+      }
+    },
+    "modelCard": {
+      "$comment": "Model card support in CycloneDX is derived from TensorFlow Model Card Toolkit released under the Apache 2.0 license and available from https://github.com/tensorflow/model-card-toolkit/blob/main/model_card_toolkit/schema/v0.0.2/model_card.schema.json. In addition, CycloneDX model card support includes portions of VerifyML, also released under the Apache 2.0 license and available from https://github.com/cylynx/verifyml/blob/main/verifyml/model_card_toolkit/schema/v0.0.4/model_card.schema.json.",
+      "type": "object",
+      "title": "Model Card",
+      "description": "A model card describes the intended uses of a machine learning model and potential limitations, including biases and ethical considerations. Model cards typically contain the training parameters, which datasets were used to train the model, performance metrics, and other relevant data useful for ML transparency. This object SHOULD be specified for any component of type `machine-learning-model` and must not be specified for other component types.",
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the model card elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+        },
+        "modelParameters": {
+          "type": "object",
+          "title": "Model Parameters",
+          "description": "Hyper-parameters for construction of the model.",
+          "additionalProperties": false,
+          "properties": {
+            "approach": {
+              "type": "object",
+              "title": "Approach",
+              "description": "The overall approach to learning used by the model for problem solving.",
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "title": "Learning Type",
+                  "description": "Learning types describing the learning problem or hybrid learning problem.",
+                  "enum": [
+                    "supervised",
+                    "unsupervised",
+                    "reinforcement-learning",
+                    "semi-supervised",
+                    "self-supervised"
+                  ],
+                  "meta:enum": {
+                    "supervised": "Supervised machine learning involves training an algorithm on labeled data to predict or classify new data based on the patterns learned from the labeled examples.",
+                    "unsupervised": "Unsupervised machine learning involves training algorithms on unlabeled data to discover patterns, structures, or relationships without explicit guidance, allowing the model to identify inherent structures or clusters within the data.",
+                    "reinforcement-learning": "Reinforcement learning is a type of machine learning where an agent learns to make decisions by interacting with an environment to maximize cumulative rewards, through trial and error.",
+                    "semi-supervised": "Semi-supervised machine learning utilizes a combination of labeled and unlabeled data during training to improve model performance, leveraging the benefits of both supervised and unsupervised learning techniques.",
+                    "self-supervised": "Self-supervised machine learning involves training models to predict parts of the input data from other parts of the same data, without requiring external labels, enabling learning from large amounts of unlabeled data."
+                  }
+                }
+              }
+            },
+            "task": {
+              "type": "string",
+              "title": "Task",
+              "description": "Directly influences the input and/or output. Examples include classification, regression, clustering, etc."
+            },
+            "architectureFamily": {
+              "type": "string",
+              "title": "Architecture Family",
+              "description": "The model architecture family such as transformer network, convolutional neural network, residual neural network, LSTM neural network, etc."
+            },
+            "modelArchitecture": {
+              "type": "string",
+              "title": "Model Architecture",
+              "description": "The specific architecture of the model such as GPT-1, ResNet-50, YOLOv3, etc."
+            },
+            "datasets": {
+              "type": "array",
+              "title": "Datasets",
+              "description": "The datasets used to train and evaluate the model.",
+              "items" : {
+                "oneOf" : [
+                  {
+                    "title": "Inline Data Information",
+                    "$ref": "#/definitions/componentData"
+                  },
+                  {
+                    "type": "object",
+                    "title": "Data Reference",
+                    "additionalProperties": false,
+                    "properties": {
+                      "ref": {
+                        "anyOf": [
+                          {
+                            "title": "Ref",
+                            "$ref": "#/definitions/refLinkType"
+                          },
+                          {
+                            "title": "BOM-Link Element",
+                            "$ref": "#/definitions/bomLinkElementType"
+                          }
+                        ],
+                        "title": "Reference",
+                        "type": "string",
+                        "description": "References a data component by the components bom-ref attribute"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "inputs": {
+              "type": "array",
+              "title": "Inputs",
+              "description": "The input format(s) of the model",
+              "items": { "$ref": "#/definitions/inputOutputMLParameters" }
+            },
+            "outputs": {
+              "type": "array",
+              "title": "Outputs",
+              "description": "The output format(s) from the model",
+              "items": { "$ref": "#/definitions/inputOutputMLParameters" }
+            }
+          }
+        },
+        "quantitativeAnalysis": {
+          "type": "object",
+          "title": "Quantitative Analysis",
+          "description": "A quantitative analysis of the model",
+          "additionalProperties": false,
+          "properties": {
+            "performanceMetrics": {
+              "type": "array",
+              "title": "Performance Metrics",
+              "description": "The model performance metrics being reported. Examples may include accuracy, F1 score, precision, top-3 error rates, MSC, etc.",
+              "items": { "$ref": "#/definitions/performanceMetric" }
+            },
+            "graphics": { "$ref": "#/definitions/graphicsCollection" }
+          }
+        },
+        "considerations": {
+          "type": "object",
+          "title": "Considerations",
+          "description": "What considerations should be taken into account regarding the model's construction, training, and application?",
+          "additionalProperties": false,
+          "properties": {
+            "users": {
+              "type": "array",
+              "title": "Users",
+              "description": "Who are the intended users of the model?",
+              "items": {
+                "type": "string"
+              }
+            },
+            "useCases": {
+              "type": "array",
+              "title": "Use Cases",
+              "description": "What are the intended use cases of the model?",
+              "items": {
+                "type": "string"
+              }
+            },
+            "technicalLimitations": {
+              "type": "array",
+              "title": "Technical Limitations",
+              "description": "What are the known technical limitations of the model? E.g. What kind(s) of data should the model be expected not to perform well on? What are the factors that might degrade model performance?",
+              "items": {
+                "type": "string"
+              }
+            },
+            "performanceTradeoffs": {
+              "type": "array",
+              "title": "Performance Tradeoffs",
+              "description": "What are the known tradeoffs in accuracy/performance of the model?",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ethicalConsiderations": {
+              "type": "array",
+              "title": "Ethical Considerations",
+              "description": "What are the ethical risks involved in the application of this model?",
+              "items": { "$ref": "#/definitions/risk" }
+            },
+            "environmentalConsiderations":{
+              "$ref": "#/definitions/environmentalConsiderations",
+              "title": "Environmental Considerations",
+              "description": "What are the various environmental impacts the corresponding machine learning model has exhibited across its lifecycle?"
+            },
+            "fairnessAssessments": {
+              "type": "array",
+              "title": "Fairness Assessments",
+              "description": "How does the model affect groups at risk of being systematically disadvantaged? What are the harms and benefits to the various affected groups?",
+              "items": {
+                "$ref": "#/definitions/fairnessAssessment"
+              }
+            }
+          }
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {"$ref": "#/definitions/property"}
+        }
+      }
+    },
+    "inputOutputMLParameters": {
+      "type": "object",
+      "title": "Input and Output Parameters",
+      "additionalProperties": false,
+      "properties": {
+        "format": {
+          "title": "Input/Output Format",
+          "description": "The data format for input/output to the model.",
+          "type": "string",
+          "examples": [ "string", "image", "time-series"]
+        }
+      }
+    },
+    "componentData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the dataset elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+        },
+        "type": {
+          "type": "string",
+          "title": "Type of Data",
+          "description": "The general theme or subject matter of the data being specified.",
+          "enum": [
+            "source-code",
+            "configuration",
+            "dataset",
+            "definition",
+            "other"
+          ],
+          "meta:enum": {
+            "source-code": "Any type of code, code snippet, or data-as-code.",
+            "configuration": "Parameters or settings that may be used by other components.",
+            "dataset": "A collection of data.",
+            "definition": "Data that can be used to create new instances of what the definition defines.",
+            "other": "Any other type of data that does not fit into existing definitions."
+          }
+        },
+        "name": {
+          "title": "Dataset Name",
+          "description": "The name of the dataset.",
+          "type": "string"
+        },
+        "contents": {
+          "type": "object",
+          "title": "Data Contents",
+          "description": "The contents or references to the contents of the data being described.",
+          "additionalProperties": false,
+          "properties": {
+            "attachment": {
+              "title": "Data Attachment",
+              "description": "A way to include textual or encoded data.",
+              "$ref": "#/definitions/attachment"
+            },
+            "url": {
+              "type": "string",
+              "title": "Data URL",
+              "description": "The URL to where the data can be retrieved.",
+              "format": "iri-reference"
+            },
+            "properties": {
+              "type": "array",
+              "title": "Configuration Properties",
+              "description": "Provides the ability to document name-value parameters used for configuration.",
+              "items": {
+                "$ref": "#/definitions/property"
+              }
+            }
+          }
+        },
+        "classification": {
+          "$ref": "#/definitions/dataClassification"
+        },
+        "sensitiveData": {
+          "type": "array",
+          "title": "Sensitive Data",
+          "description": "A description of any sensitive data in a dataset.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "graphics": { "$ref": "#/definitions/graphicsCollection" },
+        "description": {
+          "title": "Dataset Description",
+          "description": "A description of the dataset. Can describe size of dataset, whether it's used for source code, training, testing, or validation, etc.",
+          "type": "string"
+        },
+        "governance": {
+          "title": "Data Governance",
+          "$ref": "#/definitions/dataGovernance"
+        }
+      }
+    },
+    "dataGovernance": {
+      "type": "object",
+      "title": "Data Governance",
+      "description": "Data governance captures information regarding data ownership, stewardship, and custodianship, providing insights into the individuals or entities responsible for managing, overseeing, and safeguarding the data throughout its lifecycle.",
+      "additionalProperties": false,
+      "properties": {
+        "custodians": {
+          "type": "array",
+          "title": "Data Custodians",
+          "description": "Data custodians are responsible for the safe custody, transport, and storage of data.",
+          "items": { "$ref": "#/definitions/dataGovernanceResponsibleParty" }
+        },
+        "stewards": {
+          "type": "array",
+          "title": "Data Stewards",
+          "description": "Data stewards are responsible for data content, context, and associated business rules.",
+          "items": { "$ref": "#/definitions/dataGovernanceResponsibleParty" }
+        },
+        "owners": {
+          "type": "array",
+          "title": "Data Owners",
+          "description": "Data owners are concerned with risk and appropriate access to data.",
+          "items": { "$ref": "#/definitions/dataGovernanceResponsibleParty" }
+        }
+      }
+    },
+    "dataGovernanceResponsibleParty": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "organization": {
+          "title": "Organization",
+          "description": "The organization that is responsible for specific data governance role(s).",
+          "$ref": "#/definitions/organizationalEntity"
+        },
+        "contact": {
+          "title": "Individual",
+          "description": "The individual that is responsible for specific data governance role(s).",
+          "$ref": "#/definitions/organizationalContact"
+        }
+      },
+      "oneOf":[
+        {
+          "required": ["organization"]
+        },
+        {
+          "required": ["contact"]
+        }
+      ]
+    },
+    "graphicsCollection": {
+      "type": "object",
+      "title": "Graphics Collection",
+      "description": "A collection of graphics that represent various measurements.",
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "title": "Description",
+          "description": "A description of this collection of graphics.",
+          "type": "string"
+        },
+        "collection": {
+          "title": "Collection",
+          "description": "A collection of graphics.",
+          "type": "array",
+          "items": { "$ref": "#/definitions/graphic" }
+        }
+      }
+    },
+    "graphic": {
+      "type": "object",
+      "title": "Graphic",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "title": "Name",
+          "description": "The name of the graphic.",
+          "type": "string"
+        },
+        "image": {
+          "title": "Graphic Image",
+          "description": "The graphic (vector or raster). Base64 encoding must be specified for binary images.",
+          "$ref": "#/definitions/attachment"
+        }
+      }
+    },
+    "performanceMetric": {
+      "type": "object",
+      "title": "Performance Metric",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "Type",
+          "description": "The type of performance metric.",
+          "type": "string"
+        },
+        "value": {
+          "title": "Value",
+          "description": "The value of the performance metric.",
+          "type": "string"
+        },
+        "slice": {
+          "title": "Slice",
+          "description": "The name of the slice this metric was computed on. By default, assume this metric is not sliced.",
+          "type": "string"
+        },
+        "confidenceInterval": {
+          "title": "Confidence Interval",
+          "description": "The confidence interval of the metric.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "lowerBound": {
+              "title": "Lower Bound",
+              "description": "The lower bound of the confidence interval.",
+              "type": "string"
+            },
+            "upperBound": {
+              "title": "Upper Bound",
+              "description": "The upper bound of the confidence interval.",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "risk": {
+      "type": "object",
+      "title": "Risk",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "title": "Name",
+          "description": "The name of the risk.",
+          "type": "string"
+        },
+        "mitigationStrategy": {
+          "title": "Mitigation Strategy",
+          "description": "Strategy used to address this risk.",
+          "type": "string"
+        }
+      }
+    },
+    "fairnessAssessment": {
+      "type": "object",
+      "title": "Fairness Assessment",
+      "description": "Information about the benefits and harms of the model to an identified at risk group.",
+      "additionalProperties": false,
+      "properties": {
+        "groupAtRisk": {
+          "type": "string",
+          "title": "Group at Risk",
+          "description": "The groups or individuals at risk of being systematically disadvantaged by the model."
+        },
+        "benefits": {
+          "type": "string",
+          "title": "Benefits",
+          "description": "Expected benefits to the identified groups."
+        },
+        "harms": {
+          "type": "string",
+          "title": "Harms",
+          "description": "Expected harms to the identified groups."
+        },
+        "mitigationStrategy": {
+          "type": "string",
+          "title": "Mitigation Strategy",
+          "description": "With respect to the benefits and harms outlined, please describe any mitigation strategy implemented."
+        }
+      }
+    },
+    "dataClassification": {
+      "type": "string",
+      "title": "Data Classification",
+      "description": "Data classification tags data according to its type, sensitivity, and value if altered, stolen, or destroyed."
+    },
+    "environmentalConsiderations": {
+      "type": "object",
+      "title": "Environmental Considerations",
+      "description": "Describes various environmental impact metrics.",
+      "additionalProperties": false,
+      "properties": {
+        "energyConsumptions": {
+          "title": "Energy Consumptions",
+          "description": "Describes energy consumption information incurred for one or more component lifecycle activities.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/energyConsumption"
+          }
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "energyConsumption": {
+      "title": "Energy consumption",
+      "description": "Describes energy consumption information incurred for the specified lifecycle activity.",
+      "type": "object",
+      "required": [
+        "activity",
+        "energyProviders",
+        "activityEnergyCost"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "activity": {
+          "type": "string",
+          "title": "Activity",
+          "description": "The type of activity that is part of a machine learning model development or operational lifecycle.",
+          "enum": [
+            "design",
+            "data-collection",
+            "data-preparation",
+            "training",
+            "fine-tuning",
+            "validation",
+            "deployment",
+            "inference",
+            "other"
+          ],
+          "meta:enum": {
+            "design": "A model design including problem framing, goal definition and algorithm selection.",
+            "data-collection": "Model data acquisition including search, selection and transfer.",
+            "data-preparation": "Model data preparation including data cleaning, labeling and conversion.",
+            "training": "Model building, training and generalized tuning.",
+            "fine-tuning": "Refining a trained model to produce desired outputs for a given problem space.",
+            "validation": "Model validation including model output evaluation and testing.",
+            "deployment": "Explicit model deployment to a target hosting infrastructure.",
+            "inference": "Generating an output response from a hosted model from a set of inputs.",
+            "other": "A lifecycle activity type whose description does not match currently defined values."
+          }
+        },
+        "energyProviders": {
+          "title": "Energy Providers",
+          "description": "The provider(s) of the energy consumed by the associated model development lifecycle activity.",
+          "type": "array",
+          "items": { "$ref": "#/definitions/energyProvider" }
+        },
+        "activityEnergyCost": {
+          "title": "Activity Energy Cost",
+          "description": "The total energy cost associated with the model lifecycle activity.",
+          "$ref": "#/definitions/energyMeasure"
+        },
+        "co2CostEquivalent": {
+          "title": "CO2 Equivalent Cost",
+          "description": "The CO2 cost (debit) equivalent to the total energy cost.",
+          "$ref": "#/definitions/co2Measure"
+        },
+        "co2CostOffset": {
+          "title": "CO2 Cost Offset",
+          "description": "The CO2 offset (credit) for the CO2 equivalent cost.",
+          "$ref": "#/definitions/co2Measure"
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "energyMeasure": {
+      "type": "object",
+      "title": "Energy Measure",
+      "description": "A measure of energy.",
+      "required": [
+        "value",
+        "unit"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "type": "number",
+          "title": "Value",
+          "description": "Quantity of energy."
+        },
+        "unit": {
+          "type": "string",
+          "enum": [ "kWh" ],
+          "title": "Unit",
+          "description": "Unit of energy.",
+          "meta:enum": {
+            "kWh": "Kilowatt-hour (kWh) is the energy delivered by one kilowatt (kW) of power for one hour (h)."
+          }
+        }
+      }
+    },
+    "co2Measure": {
+      "type": "object",
+      "title": "CO2 Measure",
+      "description": "A measure of carbon dioxide (CO2).",
+      "required": [
+        "value",
+        "unit"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "type": "number",
+          "title": "Value",
+          "description": "Quantity of carbon dioxide (CO2)."
+        },
+        "unit": {
+          "type": "string",
+          "enum": [ "tCO2eq" ],
+          "title": "Unit",
+          "description": "Unit of carbon dioxide (CO2).",
+          "meta:enum": {
+            "tCO2eq": "Tonnes (t) of carbon dioxide (CO2) equivalent (eq)."
+          }
+        }
+      }
+    },
+    "energyProvider": {
+      "type": "object",
+      "title": "Energy Provider",
+      "description": "Describes the physical provider of energy used for model development or operations.",
+      "required": [
+        "organization",
+        "energySource",
+        "energyProvided"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the energy provider elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "$ref": "#/definitions/refType"
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A description of the energy provider."
+        },
+        "organization": {
+          "type": "object",
+          "title": "Organization",
+          "description": "The organization that provides energy.",
+          "$ref": "#/definitions/organizationalEntity"
+        },
+        "energySource": {
+          "type": "string",
+          "enum": [
+            "coal",
+            "oil",
+            "natural-gas",
+            "nuclear",
+            "wind",
+            "solar",
+            "geothermal",
+            "hydropower",
+            "biofuel",
+            "unknown",
+            "other"
+          ],
+          "meta:enum": {
+            "coal": "Energy produced by types of coal.",
+            "oil": "Petroleum products (primarily crude oil and its derivative fuel oils).",
+            "natural-gas": "Hydrocarbon gas liquids (HGL) that occur as gases at atmospheric pressure and as liquids under higher pressures including Natural gas (C5H12 and heavier), Ethane (C2H6), Propane (C3H8), etc.",
+            "nuclear": "Energy produced from the cores of atoms (i.e., through nuclear fission or fusion).",
+            "wind": "Energy produced from moving air.",
+            "solar": "Energy produced from the sun (i.e., solar radiation).",
+            "geothermal": "Energy produced from heat within the earth.",
+            "hydropower": "Energy produced from flowing water.",
+            "biofuel": "Liquid fuels produced from biomass feedstocks (i.e., organic materials such as plants or animals).",
+            "unknown": "The energy source is unknown.",
+            "other": "An energy source that is not listed."
+          },
+          "title": "Energy Source",
+          "description": "The energy source for the energy provider."
+        },
+        "energyProvided": {
+          "$ref": "#/definitions/energyMeasure",
+          "title": "Energy Provided",
+          "description": "The energy provided by the energy source for an associated activity."
+        },
+        "externalReferences": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/externalReference"},
+          "title": "External References",
+          "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+        }
+      }
+    },
+    "postalAddress": {
+      "type": "object",
+      "title": "Postal address",
+      "description": "An address used to identify a contactable location.",
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the address elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "$ref": "#/definitions/refType"
+        },
+        "country": {
+          "type": "string",
+          "title": "Country",
+          "description": "The country name or the two-letter ISO 3166-1 country code."
+        },
+        "region": {
+          "type": "string",
+          "title": "Region",
+          "description": "The region or state in the country.",
+          "examples": [ "Texas" ]
+        },
+        "locality": {
+          "type": "string",
+          "title": "Locality",
+          "description": "The locality or city within the country.",
+          "examples": [ "Austin" ]
+        },
+        "postOfficeBoxNumber": {
+          "type": "string",
+          "title": "Post Office Box Number",
+          "description": "The post office box number.",
+          "examples": [ "901" ]
+        },
+        "postalCode": {
+          "type": "string",
+          "title": "Postal Code",
+          "description": "The postal code.",
+          "examples": [ "78758" ]
+        },
+        "streetAddress": {
+          "type": "string",
+          "title": "Street Address",
+          "description": "The street address.",
+          "examples": [ "100 Main Street" ]
+        }
+      }
+    },
+    "formula": {
+      "title": "Formula",
+      "description": "Describes workflows and resources that captures rules and other aspects of how the associated BOM component or service was formed.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the formula elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "$ref": "#/definitions/refType"
+        },
+        "components": {
+          "title": "Components",
+          "description": "Transient components that are used in tasks that constitute one or more of this formula's workflows",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/component"
+          },
+          "uniqueItems": true
+        },
+        "services": {
+          "title": "Services",
+          "description": "Transient services that are used in tasks that constitute one or more of this formula's workflows",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/service"
+          },
+          "uniqueItems": true
+        },
+        "workflows": {
+          "title": "Workflows",
+          "description": "List of workflows that can be declared to accomplish specific orchestrated goals and independently triggered.",
+          "$comment": "Different workflows can be designed to work together to perform end-to-end CI/CD builds and deployments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/workflow"
+          },
+          "uniqueItems": true
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "workflow": {
+      "title": "Workflow",
+      "description": "A specialized orchestration task.",
+      "$comment": "Workflow are as task themselves and can trigger other workflow tasks.  These relationships can be modeled in the taskDependencies graph.",
+      "type": "object",
+      "required": [
+        "bom-ref",
+        "uid",
+        "taskTypes"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the workflow elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "$ref": "#/definitions/refType"
+        },
+        "uid": {
+          "title": "Unique Identifier (UID)",
+          "description": "The unique identifier for the resource instance within its deployment context.",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "description": "The name of the resource instance.",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "description": "A description of the resource instance.",
+          "type": "string"
+        },
+        "resourceReferences": {
+          "title": "Resource references",
+          "description": "References to component or service resources that are used to realize the resource instance.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/resourceReferenceChoice"
+          }
+        },
+        "tasks": {
+          "title": "Tasks",
+          "description": "The tasks that comprise the workflow.",
+          "$comment": "Note that tasks can appear more than once as different instances (by name or UID).",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/task"
+          }
+        },
+        "taskDependencies": {
+          "title": "Task dependency graph",
+          "description": "The graph of dependencies between tasks within the workflow.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/dependency"
+          }
+        },
+        "taskTypes": {
+          "title": "Task types",
+          "description": "Indicates the types of activities performed by the set of workflow tasks.",
+          "$comment": "Currently, these types reflect common CI/CD actions.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/taskType"
+          }
+        },
+        "trigger": {
+          "title": "Trigger",
+          "description": "The trigger that initiated the task.",
+          "$ref": "#/definitions/trigger"
+        },
+        "steps": {
+          "title": "Steps",
+          "description": "The sequence of steps for the task.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "uniqueItems": true
+        },
+        "inputs": {
+          "title": "Inputs",
+          "description": "Represents resources and data brought into a task at runtime by executor or task commands",
+          "examples": ["a `configuration` file which was declared as a local `component` or `externalReference`"],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/inputType"
+          },
+          "uniqueItems": true
+        },
+        "outputs": {
+          "title": "Outputs",
+          "description": "Represents resources and data output from a task at runtime by executor or task commands",
+          "examples": ["a log file or metrics data produced by the task"],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/outputType"
+          },
+          "uniqueItems": true
+        },
+        "timeStart": {
+          "title": "Time start",
+          "description": "The date and time (timestamp) when the task started.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "timeEnd": {
+          "title": "Time end",
+          "description": "The date and time (timestamp) when the task ended.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "workspaces": {
+          "title": "Workspaces",
+          "description": "A set of named filesystem or data resource shareable by workflow tasks.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/workspace"
+          }
+        },
+        "runtimeTopology": {
+          "title": "Runtime topology",
+          "description": "A graph of the component runtime topology for workflow's instance.",
+          "$comment": "A description of the runtime component and service topology.  This can describe a partial or complete topology used to host and execute the task (e.g., hardware, operating systems, configurations, etc.),",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/dependency"
+          }
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "task": {
+      "title": "Task",
+      "description": "Describes the inputs, sequence of steps and resources used to accomplish a task and its output.",
+      "$comment": "Tasks are building blocks for constructing assemble CI/CD workflows or pipelines.",
+      "type": "object",
+      "required": [
+        "bom-ref",
+        "uid",
+        "taskTypes"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the task elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "$ref": "#/definitions/refType"
+        },
+        "uid": {
+          "title": "Unique Identifier (UID)",
+          "description": "The unique identifier for the resource instance within its deployment context.",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "description": "The name of the resource instance.",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "description": "A description of the resource instance.",
+          "type": "string"
+        },
+        "resourceReferences": {
+          "title": "Resource references",
+          "description": "References to component or service resources that are used to realize the resource instance.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/resourceReferenceChoice"
+          }
+        },
+        "taskTypes": {
+          "title": "Task types",
+          "description": "Indicates the types of activities performed by the set of workflow tasks.",
+          "$comment": "Currently, these types reflect common CI/CD actions.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/taskType"
+          }
+        },
+        "trigger": {
+          "title": "Trigger",
+          "description": "The trigger that initiated the task.",
+          "$ref": "#/definitions/trigger"
+        },
+        "steps": {
+          "title": "Steps",
+          "description": "The sequence of steps for the task.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "uniqueItems": true
+        },
+        "inputs": {
+          "title": "Inputs",
+          "description": "Represents resources and data brought into a task at runtime by executor or task commands",
+          "examples": ["a `configuration` file which was declared as a local `component` or `externalReference`"],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/inputType"
+          },
+          "uniqueItems": true
+        },
+        "outputs": {
+          "title": "Outputs",
+          "description": "Represents resources and data output from a task at runtime by executor or task commands",
+          "examples": ["a log file or metrics data produced by the task"],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/outputType"
+          },
+          "uniqueItems": true
+        },
+        "timeStart": {
+          "title": "Time start",
+          "description": "The date and time (timestamp) when the task started.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "timeEnd": {
+          "title": "Time end",
+          "description": "The date and time (timestamp) when the task ended.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "workspaces": {
+          "title": "Workspaces",
+          "description": "A set of named filesystem or data resource shareable by workflow tasks.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/workspace"
+          },
+          "uniqueItems": true
+        },
+        "runtimeTopology": {
+          "title": "Runtime topology",
+          "description": "A graph of the component runtime topology for task's instance.",
+          "$comment": "A description of the runtime component and service topology.  This can describe a partial or complete topology used to host and execute the task (e.g., hardware, operating systems, configurations, etc.),",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/dependency"
+          },
+          "uniqueItems": true
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "step": {
+      "type": "object",
+      "description": "Executes specific commands or tools in order to accomplish its owning task as part of a sequence.",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "title": "Name",
+          "description": "A name for the step.",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "description": "A description of the step.",
+          "type": "string"
+        },
+        "commands": {
+          "title": "Commands",
+          "description": "Ordered list of commands or directives for the step",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/command"
+          }
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "command": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "executed": {
+          "title": "Executed",
+          "description": "A text representation of the executed command.",
+          "type": "string"
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "workspace": {
+      "title": "Workspace",
+      "description": "A named filesystem or data resource shareable by workflow tasks.",
+      "type": "object",
+      "required": [
+        "bom-ref",
+        "uid"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the workspace elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "$ref": "#/definitions/refType"
+        },
+        "uid": {
+          "title": "Unique Identifier (UID)",
+          "description": "The unique identifier for the resource instance within its deployment context.",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "description": "The name of the resource instance.",
+          "type": "string"
+        },
+        "aliases": {
+          "title": "Aliases",
+          "description": "The names for the workspace as referenced by other workflow tasks. Effectively, a name mapping so other tasks can use their own local name in their steps.",
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "description": {
+          "title": "Description",
+          "description": "A description of the resource instance.",
+          "type": "string"
+        },
+        "resourceReferences": {
+          "title": "Resource references",
+          "description": "References to component or service resources that are used to realize the resource instance.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/resourceReferenceChoice"
+          }
+        },
+        "accessMode": {
+          "title": "Access mode",
+          "description": "Describes the read-write access control for the workspace relative to the owning resource instance.",
+          "type": "string",
+          "enum": [
+            "read-only",
+            "read-write",
+            "read-write-once",
+            "write-once",
+            "write-only"
+          ]
+        },
+        "mountPath": {
+          "title": "Mount path",
+          "description": "A path to a location on disk where the workspace will be available to the associated task's steps.",
+          "type": "string"
+        },
+        "managedDataType": {
+          "title": "Managed data type",
+          "description": "The name of a domain-specific data type the workspace represents.",
+          "$comment": "This property is for CI/CD frameworks that are able to provide access to structured, managed data at a more granular level than a filesystem.",
+          "examples": ["ConfigMap","Secret"],
+          "type": "string"
+        },
+        "volumeRequest": {
+          "title": "Volume request",
+          "description": "Identifies the reference to the request for a specific volume type and parameters.",
+          "examples": ["a kubernetes Persistent Volume Claim (PVC) name"],
+          "type": "string"
+        },
+        "volume": {
+          "title": "Volume",
+          "description": "Information about the actual volume instance allocated to the workspace.",
+          "$comment": "The actual volume allocated may be different than the request.",
+          "examples": ["see https://kubernetes.io/docs/concepts/storage/persistent-volumes/"],
+          "$ref": "#/definitions/volume"
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "volume": {
+      "title": "Volume",
+      "description": "An identifiable, logical unit of data storage tied to a physical device.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "uid": {
+          "title": "Unique Identifier (UID)",
+          "description": "The unique identifier for the volume instance within its deployment context.",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "description": "The name of the volume instance",
+          "type": "string"
+        },
+        "mode": {
+          "title": "Mode",
+          "description": "The mode for the volume instance.",
+          "type": "string",
+          "enum": [
+            "filesystem", "block"
+          ],
+          "default": "filesystem"
+        },
+        "path": {
+          "title": "Path",
+          "description": "The underlying path created from the actual volume.",
+          "type": "string"
+        },
+        "sizeAllocated": {
+          "title": "Size allocated",
+          "description": "The allocated size of the volume accessible to the associated workspace. This should include the scalar size as well as IEC standard unit in either decimal or binary form.",
+          "examples": ["10GB", "2Ti", "1Pi"],
+          "type": "string"
+        },
+        "persistent": {
+          "title": "Persistent",
+          "description": "Indicates if the volume persists beyond the life of the resource it is associated with.",
+          "type": "boolean"
+        },
+        "remote": {
+          "title": "Remote",
+          "description": "Indicates if the volume is remotely (i.e., network) attached.",
+          "type": "boolean"
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "trigger": {
+      "title": "Trigger",
+      "description": "Represents a resource that can conditionally activate (or fire) tasks based upon associated events and their data.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "bom-ref",
+        "uid"
+      ],
+      "properties": {
+        "bom-ref": {
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the trigger elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "$ref": "#/definitions/refType"
+        },
+        "uid": {
+          "title": "Unique Identifier (UID)",
+          "description": "The unique identifier for the resource instance within its deployment context.",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "description": "The name of the resource instance.",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "description": "A description of the resource instance.",
+          "type": "string"
+        },
+        "resourceReferences": {
+          "title": "Resource references",
+          "description": "References to component or service resources that are used to realize the resource instance.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/resourceReferenceChoice"
+          }
+        },
+        "type": {
+          "title": "Type",
+          "description": "The source type of event which caused the trigger to fire.",
+          "type": "string",
+          "enum": [
+            "manual",
+            "api",
+            "webhook",
+            "scheduled"
+          ]
+        },
+        "event": {
+          "title": "Event",
+          "description": "The event data that caused the associated trigger to activate.",
+          "$ref": "#/definitions/event"
+        },
+        "conditions": {
+          "type": "array",
+          "title": "Conditions",
+          "description": "A list of conditions used to determine if a trigger should be activated.",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/condition"
+          }
+        },
+        "timeActivated": {
+          "title": "Time activated",
+          "description": "The date and time (timestamp) when the trigger was activated.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "inputs": {
+          "title": "Inputs",
+          "description": "Represents resources and data brought into a task at runtime by executor or task commands",
+          "examples": ["a `configuration` file which was declared as a local `component` or `externalReference`"],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/inputType"
+          },
+          "uniqueItems": true
+        },
+        "outputs": {
+          "title": "Outputs",
+          "description": "Represents resources and data output from a task at runtime by executor or task commands",
+          "examples": ["a log file or metrics data produced by the task"],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/outputType"
+          },
+          "uniqueItems": true
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "event": {
+      "title": "Event",
+      "description": "Represents something that happened that may trigger a response.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "uid": {
+          "title": "Unique Identifier (UID)",
+          "description": "The unique identifier of the event.",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "description": "A description of the event.",
+          "type": "string"
+        },
+        "timeReceived": {
+          "title": "Time Received",
+          "description": "The date and time (timestamp) when the event was received.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "data": {
+          "title": "Data",
+          "description": "Encoding of the raw event data.",
+          "$ref": "#/definitions/attachment"
+        },
+        "source": {
+          "title": "Source",
+          "description": "References the component or service that was the source of the event",
+          "$ref": "#/definitions/resourceReferenceChoice"
+        },
+        "target": {
+          "title": "Target",
+          "description": "References the component or service that was the target of the event",
+          "$ref": "#/definitions/resourceReferenceChoice"
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "inputType": {
+      "title": "Input type",
+      "description": "Type that represents various input data types and formats.",
+      "type": "object",
+      "oneOf": [
+        {
+          "required": [
+            "resource"
+          ]
+        },
+        {
+          "required": [
+            "parameters"
+          ]
+        },
+        {
+          "required": [
+            "environmentVars"
+          ]
+        },
+        {
+          "required": [
+            "data"
+          ]
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "title": "Source",
+          "description": "A reference to the component or service that provided the input to the task (e.g., reference to a service with data flow value of `inbound`)",
+          "examples": [
+            "source code repository",
+            "database"
+          ],
+          "$ref": "#/definitions/resourceReferenceChoice"
+        },
+        "target": {
+          "title": "Target",
+          "description": "A reference to the component or service that received or stored the input if not the task itself (e.g., a local, named storage workspace)",
+          "examples": [
+            "workspace",
+            "directory"
+          ],
+          "$ref": "#/definitions/resourceReferenceChoice"
+        },
+        "resource": {
+          "title": "Resource",
+          "description": "A reference to an independent resource provided as an input to a task by the workflow runtime.",
+          "examples": [
+            "a reference to a configuration file in a repository (i.e., a bom-ref)",
+            "a reference to a scanning service used in a task (i.e., a bom-ref)"
+          ],
+          "$ref": "#/definitions/resourceReferenceChoice"
+        },
+        "parameters": {
+          "title": "Parameters",
+          "description": "Inputs that have the form of parameters with names and values.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/parameter"
+          }
+        },
+        "environmentVars": {
+          "title": "Environment variables",
+          "description": "Inputs that have the form of parameters with names and values.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/property"
+              },
+              {
+                "type": "string",
+                "title": "String-Based Environment Variables",
+                "description": "In addition to the more common key–value pair format, some environment variables may consist of a single string without an explicit value assignment. These string-based environment variables typically act as flags or signals to software, indicating that a feature should be enabled, a mode should be activated, or a specific condition is present. Their presence alone conveys meaning."
+              }
+            ]
+          }
+        },
+        "data": {
+          "title": "Data",
+          "description": "Inputs that have the form of data.",
+          "$ref": "#/definitions/attachment"
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "outputType": {
+      "type": "object",
+      "oneOf": [
+        {
+          "required": [
+            "resource"
+          ]
+        },
+        {
+          "required": [
+            "environmentVars"
+          ]
+        },
+        {
+          "required": [
+            "data"
+          ]
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "Type",
+          "description": "Describes the type of data output.",
+          "type": "string",
+          "enum": [
+            "artifact",
+            "attestation",
+            "log",
+            "evidence",
+            "metrics",
+            "other"
+          ]
+        },
+        "source": {
+          "title": "Source",
+          "description": "Component or service that generated or provided the output from the task (e.g., a build tool)",
+          "$ref": "#/definitions/resourceReferenceChoice"
+        },
+        "target": {
+          "title": "Target",
+          "description": "Component or service that received the output from the task (e.g., reference to an artifactory service with data flow value of `outbound`)",
+          "examples": ["a log file described as an `externalReference` within its target domain."],
+          "$ref": "#/definitions/resourceReferenceChoice"
+        },
+        "resource": {
+          "title": "Resource",
+          "description": "A reference to an independent resource generated as output by the task.",
+          "examples": [
+            "configuration file",
+            "source code",
+            "scanning service"
+          ],
+          "$ref": "#/definitions/resourceReferenceChoice"
+        },
+        "data": {
+          "title": "Data",
+          "description": "Outputs that have the form of data.",
+          "$ref": "#/definitions/attachment"
+        },
+        "environmentVars": {
+          "title": "Environment variables",
+          "description": "Outputs that have the form of environment variables.",
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/property"
+              },
+              {
+                "type": "string",
+                "title": "String-Based Environment Variables",
+                "description": "In addition to the more common key–value pair format, some environment variables may consist of a single string without an explicit value assignment. These string-based environment variables typically act as flags or signals to software, indicating that a feature should be enabled, a mode should be activated, or a specific condition is present. Their presence alone conveys meaning."
+              }
+            ]
+          },
+          "uniqueItems": true
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "resourceReferenceChoice": {
+      "title": "Resource reference choice",
+      "description": "A reference to a locally defined resource (e.g., a bom-ref) or an externally accessible resource.",
+      "$comment": "Enables reference to a resource that participates in a workflow; using either internal (bom-ref) or external (externalReference) types.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ref": {
+          "title": "BOM Reference",
+          "description": "References an object by its bom-ref attribute",
+          "anyOf": [
+            {
+              "title": "Ref",
+              "$ref": "#/definitions/refLinkType"
+            },
+            {
+              "title": "BOM-Link Element",
+              "$ref": "#/definitions/bomLinkElementType"
+            }
+          ]
+        },
+        "externalReference": {
+          "title": "External reference",
+          "description": "Reference to an externally accessible resource.",
+          "$ref": "#/definitions/externalReference"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "ref"
+          ]
+        },
+        {
+          "required": [
+            "externalReference"
+          ]
+        }
+      ]
+    },
+    "condition": {
+      "title": "Condition",
+      "description": "A condition that was used to determine a trigger should be activated.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "title": "Description",
+          "description": "Describes the set of conditions which cause the trigger to activate.",
+          "type": "string"
+        },
+        "expression": {
+          "title": "Expression",
+          "description": "The logical expression that was evaluated that determined the trigger should be fired.",
+          "type": "string"
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "taskType": {
+      "type": "string",
+      "enum": [
+        "copy",
+        "clone",
+        "lint",
+        "scan",
+        "merge",
+        "build",
+        "test",
+        "deliver",
+        "deploy",
+        "release",
+        "clean",
+        "other"
+      ],
+      "meta:enum": {
+        "copy": "A task that copies software or data used to accomplish other tasks in the workflow.",
+        "clone": "A task that clones a software repository into the workflow in order to retrieve its source code or data for use in a build step.",
+        "lint": "A task that checks source code for programmatic and stylistic errors.",
+        "scan": "A task that performs a scan against source code, or built or deployed components and services. Scans are typically run to gather or test for security vulnerabilities or policy compliance.",
+        "merge": "A task that merges changes or fixes into source code prior to a build step in the workflow.",
+        "build": "A task that builds the source code, dependencies and/or data into an artifact that can be deployed to and executed on target systems.",
+        "test": "A task that verifies the functionality of a component or service.",
+        "deliver": "A task that delivers a built artifact to one or more target repositories or storage systems.",
+        "deploy": "A task that deploys a built artifact for execution on one or more target systems.",
+        "release": "A task that releases a built, versioned artifact to a target repository or distribution system.",
+        "clean": "A task that cleans unnecessary tools, build artifacts and/or data from workflow storage.",
+        "other": "A workflow task that does not match current task type definitions."
+      }
+    },
+    "parameter": {
+      "title": "Parameter",
+      "description": "A representation of a functional parameter.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "title": "Name",
+          "description": "The name of the parameter.",
+          "type": "string"
+        },
+        "value": {
+          "title": "Value",
+          "description": "The value of the parameter.",
+          "type": "string"
+        },
+        "dataType": {
+          "title": "Data type",
+          "description": "The data type of the parameter.",
+          "type": "string"
+        }
+      }
+    },
+    "componentIdentityEvidence": {
+      "type": "object",
+      "title": "Identity Evidence",
+      "description": "Evidence that substantiates the identity of a component.",
+      "required": [ "field" ],
+      "additionalProperties": false,
+      "properties": {
+        "field": {
+          "type": "string",
+          "enum": [
+            "group", "name", "version", "purl", "cpe", "omniborId", "swhid", "swid", "hash"
+          ],
+          "title": "Field",
+          "description": "The identity field of the component which the evidence describes."
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "title": "Confidence",
+          "description": "The overall confidence of the evidence from 0 - 1, where 1 is 100% confidence."
+        },
+        "concludedValue": {
+          "type": "string",
+          "title": "Concluded Value",
+          "description": "The value of the field (cpe, purl, etc) that has been concluded based on the aggregate of all methods (if available)."
+        },
+        "methods": {
+          "type": "array",
+          "title": "Methods",
+          "description": "The methods used to extract and/or analyze the evidence.",
+          "items": {
+            "type": "object",
+            "required": [
+              "technique" ,
+              "confidence"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "technique": {
+                "title": "Technique",
+                "description": "The technique used in this method of analysis.",
+                "type": "string",
+                "enum": [
+                  "source-code-analysis",
+                  "binary-analysis",
+                  "manifest-analysis",
+                  "ast-fingerprint",
+                  "hash-comparison",
+                  "instrumentation",
+                  "dynamic-analysis",
+                  "filename",
+                  "attestation",
+                  "other"
+                ]
+              },
+              "confidence": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "title": "Confidence",
+                "description": "The confidence of the evidence from 0 - 1, where 1 is 100% confidence. Confidence is specific to the technique used. Each technique of analysis can have independent confidence."
+              },
+              "value": {
+                "type": "string",
+                "title": "Value",
+                "description": "The value or contents of the evidence."
+              }
+            }
+          }
+        },
+        "tools": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "anyOf": [
+              {
+                "title": "Ref",
+                "$ref": "#/definitions/refLinkType"
+              },
+              {
+                "title": "BOM-Link Element",
+                "$ref": "#/definitions/bomLinkElementType"
+              }
+            ]
+          },
+          "title": "BOM References",
+          "description": "The object in the BOM identified by its bom-ref. This is often a component or service but may be any object type supporting bom-refs. Tools used for analysis should already be defined in the BOM, either in the metadata/tools, components, or formulation."
+        }
+      }
+    },
+    "standard": {
+      "type": "object",
+      "title": "Standard",
+      "description": "A standard may consist of regulations, industry or organizational-specific standards, maturity models, best practices, or any other requirements which can be evaluated against or attested to.",
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the standard. This will often be a shortened, single name of the standard."
+        },
+        "version": {
+          "type": "string",
+          "title": "Version",
+          "description": "The version of the standard."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "The description of the standard."
+        },
+        "owner": {
+          "type": "string",
+          "title": "Owner",
+          "description": "The owner of the standard, often the entity responsible for its release."
+        },
+        "requirements": {
+          "type": "array",
+          "title": "Requirements",
+          "description": "The list of requirements comprising the standard.",
+          "items": {
+            "type": "object",
+            "title": "Requirement",
+            "additionalProperties": false,
+            "properties": {
+              "bom-ref": {
+                "$ref": "#/definitions/refType",
+                "title": "BOM Reference",
+                "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
+              },
+              "identifier": {
+                "type": "string",
+                "title": "Identifier",
+                "description": "The unique identifier used in the standard to identify a specific requirement. This should match what is in the standard and should not be the requirements bom-ref."
+              },
+              "title": {
+                "type": "string",
+                "title": "Title",
+                "description": "The title of the requirement."
+              },
+              "text": {
+                "type": "string",
+                "title": "Text",
+                "description": "The textual content of the requirement."
+              },
+              "descriptions": {
+                "type": "array",
+                "title": "Descriptions",
+                "description": "The supplemental text that provides additional guidance or context to the requirement, but is not directly part of the requirement.",
+                "items": { "type":  "string" }
+              },
+              "openCre": {
+                "type": "array",
+                "title": "OWASP OpenCRE Identifier(s)",
+                "description": "The Common Requirements Enumeration (CRE) identifier(s). CRE is a structured and standardized framework for uniting security standards and guidelines. CRE links each section of a resource to a shared topic identifier (a Common Requirement). Through this shared topic link, all resources map to each other. Use of CRE promotes clear and unambiguous communication among stakeholders.",
+                "items": {
+                  "type":  "string",
+                  "pattern": "^CRE:[0-9]+-[0-9]+$",
+                  "examples": [ "CRE:764-507" ]
+                }
+              },
+              "parent": {
+                "$ref": "#/definitions/refLinkType",
+                "title": "Parent BOM Reference",
+                "description": "The `bom-ref` to a parent requirement. This establishes a hierarchy of requirements. Top-level requirements must not define a parent. Only child requirements should define parents."
+              },
+              "properties": {
+                "type": "array",
+                "title": "Properties",
+                "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+                "items": {
+                  "$ref": "#/definitions/property"
+                }
+              },
+              "externalReferences": {
+                "type": "array",
+                "items": {"$ref": "#/definitions/externalReference"},
+                "title": "External References",
+                "description": "External references provide a way to document systems, sites, and information that may be relevant, but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+              }
+            }
+          }
+        },
+        "levels": {
+          "type": "array",
+          "title": "Levels",
+          "description": "The list of levels associated with the standard. Some standards have different levels of compliance.",
+          "items": {
+            "type": "object",
+            "title": "Level",
+            "additionalProperties": false,
+            "properties": {
+              "bom-ref": {
+                "$ref": "#/definitions/refType",
+                "title": "BOM Reference",
+                "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
+              },
+              "identifier": {
+                "type": "string",
+                "title": "Identifier",
+                "description": "The identifier used in the standard to identify a specific level."
+              },
+              "title": {
+                "type": "string",
+                "title": "Title",
+                "description": "The title of the level."
+              },
+              "description": {
+                "type": "string",
+                "title": "Description",
+                "description": "The description of the level."
+              },
+              "requirements": {
+                "type": "array",
+                "title": "Requirements",
+                "description": "The list of requirement `bom-ref`s that comprise the level.",
+                "items": { "$ref": "#/definitions/refLinkType" }
+              }
+            }
+          }
+        },
+        "externalReferences": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/externalReference"},
+          "title": "External References",
+          "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+        },
+        "signature": {
+          "$ref": "#/definitions/signature",
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+        }
+      }
+    },
+    "signature": {
+      "$ref": "jsf-0.82.schema.json#/definitions/signature",
+      "title": "Signature",
+      "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+    },
+    "cryptoProperties": {
+      "type": "object",
+      "title": "Cryptographic Properties",
+      "description": "Cryptographic assets have properties that uniquely define them and that make them actionable for further reasoning. As an example, it makes a difference if one knows the algorithm family (e.g. AES) or the specific variant or instantiation (e.g. AES-128-GCM). This is because the security level and the algorithm primitive (authenticated encryption) are only defined by the definition of the algorithm variant. The presence of a weak cryptographic algorithm like SHA1 vs. HMAC-SHA1 also makes a difference.",
+      "additionalProperties": false,
+      "required": [
+        "assetType"
+      ],
+      "properties": {
+        "assetType": {
+          "type": "string",
+          "title": "Asset Type",
+          "description": "Cryptographic assets occur in several forms. Algorithms and protocols are most commonly implemented in specialized cryptographic libraries. They may, however, also be 'hardcoded' in software components. Certificates and related cryptographic material like keys, tokens, secrets or passwords are other cryptographic assets to be modelled.",
+          "enum": [
+            "algorithm",
+            "certificate",
+            "protocol",
+            "related-crypto-material"
+          ],
+          "meta:enum": {
+            "algorithm": "Mathematical function commonly used for data encryption, authentication, and digital signatures.",
+            "certificate": "An electronic document that is used to provide the identity or validate a public key.",
+            "protocol": "A set of rules and guidelines that govern the behavior and communication with each other.",
+            "related-crypto-material": "Other cryptographic assets related to algorithms, certificates, and protocols such as keys and tokens."
+          }
+        },
+        "algorithmProperties": {
+          "type": "object",
+          "title": "Algorithm Properties",
+          "description": "Additional properties specific to a cryptographic algorithm.",
+          "additionalProperties": false,
+          "properties": {
+            "primitive": {
+              "type": "string",
+              "title": "primitive",
+              "description": "Cryptographic building blocks used in higher-level cryptographic systems and protocols. Primitives represent different cryptographic routines: deterministic random bit generators (drbg, e.g. CTR_DRBG from NIST SP800-90A-r1), message authentication codes (mac, e.g. HMAC-SHA-256), blockciphers (e.g. AES), streamciphers (e.g. Salsa20), signatures (e.g. ECDSA), hash functions (e.g. SHA-256), public-key encryption schemes (pke, e.g. RSA), extended output functions (xof, e.g. SHAKE256), key derivation functions (e.g. pbkdf2), key agreement algorithms (e.g. ECDH), key encapsulation mechanisms (e.g. ML-KEM), authenticated encryption (ae, e.g. AES-GCM) and the combination of multiple algorithms (combiner, e.g. SP800-56Cr2).",
+              "enum": [
+                "drbg",
+                "mac",
+                "block-cipher",
+                "stream-cipher",
+                "signature",
+                "hash",
+                "pke",
+                "xof",
+                "kdf",
+                "key-agree",
+                "kem",
+                "ae",
+                "combiner",
+                "key-wrap",
+                "other",
+                "unknown"
+              ],
+              "meta:enum": {
+                "drbg": "Deterministic Random Bit Generator (DRBG) is a type of pseudorandom number generator designed to produce a sequence of bits from an initial seed value. DRBGs are commonly used in cryptographic applications where reproducibility of random values is important.",
+                "mac": "In cryptography, a Message Authentication Code (MAC) is information used for authenticating and integrity-checking a message.",
+                "block-cipher": "A block cipher is a symmetric key algorithm that operates on fixed-size blocks of data. It encrypts or decrypts the data in block units, providing confidentiality. Block ciphers are widely used in various cryptographic modes and protocols for secure data transmission.",
+                "stream-cipher": "A stream cipher is a symmetric key cipher where plaintext digits are combined with a pseudorandom cipher digit stream (keystream).",
+                "signature": "In cryptography, a signature is a digital representation of a message or data that proves its origin, identity, and integrity. Digital signatures are generated using cryptographic algorithms and are widely used for authentication and verification in secure communication.",
+                "hash": "A hash function is a mathematical algorithm that takes an input (or 'message') and produces a fixed-size string of characters, which is typically a hash value. Hash functions are commonly used in various cryptographic applications, including data integrity verification and password hashing.",
+                "pke": "Public Key Encryption (PKE) is a type of encryption that uses a pair of public and private keys for secure communication. The public key is used for encryption, while the private key is used for decryption. PKE is a fundamental component of public-key cryptography.",
+                "xof": "An XOF is an extendable output function that can take arbitrary input and creates a stream of output, up to a limit determined by the size of the internal state of the hash function that underlies the XOF.",
+                "kdf": "A Key Derivation Function (KDF) derives key material from another source of entropy while preserving the entropy of the input.",
+                "key-agree": "In cryptography, a key-agreement is a protocol whereby two or more parties agree on a cryptographic key in such a way that both influence the outcome.",
+                "kem": "A Key Encapsulation Mechanism (KEM) algorithm is a mechanism for transporting random keying material to a recipient using the recipient's public key.",
+                "ae": "Authenticated Encryption (AE) is a cryptographic process that provides both confidentiality and data integrity. It ensures that the encrypted data has not been tampered with and comes from a legitimate source. AE is commonly used in secure communication protocols.",
+                "combiner": "A combiner aggregates many candidates for a cryptographic primitive and generates a new candidate for the same primitive.",
+                "key-wrap": "Key-wrap is a cryptographic technique used to securely encrypt and protect cryptographic keys using algorithms like AES.",
+                "other": "Another primitive type.",
+                "unknown": "The primitive is not known."
+              }
+            },
+            "algorithmFamily": {
+              "$ref": "cryptography-defs.schema.json#/definitions/algorithmFamiliesEnum",
+              "title": "Algorithm Family",
+              "description": "A valid algorithm family identifier. If specified, this value must be one of the enumeration of valid algorithm Family identifiers defined in the `cryptography-defs.schema.json` subschema.",
+              "examples": ["3DES", "Blowfish", "ECDH"]
+            },
+            "parameterSetIdentifier": {
+              "type": "string",
+              "title": "Parameter Set Identifier",
+              "description": "An identifier for the parameter set of the cryptographic algorithm. Examples: in AES128, '128' identifies the key length in bits, in SHA256, '256' identifies the digest length, '128' in SHAKE128 identifies its maximum security level in bits, and 'SHA2-128s' identifies a parameter set used in SLH-DSA (FIPS205)."
+            },
+            "curve": {
+              "deprecated": true,
+              "type": "string",
+              "title": "Elliptic Curve",
+              "description": "[Deprecated] This will be removed in a future version. Use `@.ellipticCurve` instead.\nThe specific underlying Elliptic Curve (EC) definition employed which is an indicator of the level of security strength, performance and complexity. Absent an authoritative source of curve names, CycloneDX recommends using curve names as defined at [https://neuromancer.sk/std/](https://neuromancer.sk/std/), the source of which can be found at [https://github.com/J08nY/std-curves](https://github.com/J08nY/std-curves)."
+            },
+            "ellipticCurve": {
+              "$ref": "cryptography-defs.schema.json#/definitions/ellipticCurvesEnum",
+              "title": "Elliptic Curve",
+              "description": "The specific underlying Elliptic Curve (EC) definition employed which is an indicator of the level of security strength, performance and complexity. If specified, this value must be one of the enumeration of valid elliptic curves identifiers defined in the `cryptography-defs.schema.json` subschema."
+            },
+            "executionEnvironment": {
+              "type": "string",
+              "title": "Execution Environment",
+              "description": "The target and execution environment in which the algorithm is implemented in.",
+              "enum": [
+                "software-plain-ram",
+                "software-encrypted-ram",
+                "software-tee",
+                "hardware",
+                "other",
+                "unknown"
+              ],
+              "meta:enum": {
+                "software-plain-ram": "A software implementation running in plain unencrypted RAM.",
+                "software-encrypted-ram": "A software implementation running in encrypted RAM.",
+                "software-tee": "A software implementation running in a trusted execution environment.",
+                "hardware": "A hardware implementation.",
+                "other": "Another implementation environment.",
+                "unknown": "The execution environment is not known."
+              }
+            },
+            "implementationPlatform": {
+              "type": "string",
+              "title": "Implementation platform",
+              "description": "The target platform for which the algorithm is implemented. The implementation can be 'generic', running on any platform or for a specific platform.",
+              "enum": [
+                "generic",
+                "x86_32",
+                "x86_64",
+                "armv7-a",
+                "armv7-m",
+                "armv8-a",
+                "armv8-m",
+                "armv9-a",
+                "armv9-m",
+                "s390x",
+                "ppc64",
+                "ppc64le",
+                "other",
+                "unknown"
+              ]
+            },
+            "certificationLevel": {
+              "type": "array",
+              "title": "Certification Level",
+              "description": "The certification that the implementation of the cryptographic algorithm has received, if any. Certifications include revisions and levels of FIPS 140 or Common Criteria of different Extended Assurance Levels (CC-EAL).",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "none",
+                  "fips140-1-l1",
+                  "fips140-1-l2",
+                  "fips140-1-l3",
+                  "fips140-1-l4",
+                  "fips140-2-l1",
+                  "fips140-2-l2",
+                  "fips140-2-l3",
+                  "fips140-2-l4",
+                  "fips140-3-l1",
+                  "fips140-3-l2",
+                  "fips140-3-l3",
+                  "fips140-3-l4",
+                  "cc-eal1",
+                  "cc-eal1+",
+                  "cc-eal2",
+                  "cc-eal2+",
+                  "cc-eal3",
+                  "cc-eal3+",
+                  "cc-eal4",
+                  "cc-eal4+",
+                  "cc-eal5",
+                  "cc-eal5+",
+                  "cc-eal6",
+                  "cc-eal6+",
+                  "cc-eal7",
+                  "cc-eal7+",
+                  "other",
+                  "unknown"
+                ],
+                "meta:enum": {
+                  "none": "No certification obtained",
+                  "fips140-1-l1": "FIPS 140-1 Level 1",
+                  "fips140-1-l2": "FIPS 140-1 Level 2",
+                  "fips140-1-l3": "FIPS 140-1 Level 3",
+                  "fips140-1-l4": "FIPS 140-1 Level 4",
+                  "fips140-2-l1": "FIPS 140-2 Level 1",
+                  "fips140-2-l2": "FIPS 140-2 Level 2",
+                  "fips140-2-l3": "FIPS 140-2 Level 3",
+                  "fips140-2-l4": "FIPS 140-2 Level 4",
+                  "fips140-3-l1": "FIPS 140-3 Level 1",
+                  "fips140-3-l2": "FIPS 140-3 Level 2",
+                  "fips140-3-l3": "FIPS 140-3 Level 3",
+                  "fips140-3-l4": "FIPS 140-3 Level 4",
+                  "cc-eal1": "Common Criteria - Evaluation Assurance Level 1",
+                  "cc-eal1+": "Common Criteria - Evaluation Assurance Level 1 (Augmented)",
+                  "cc-eal2": "Common Criteria - Evaluation Assurance Level 2",
+                  "cc-eal2+": "Common Criteria - Evaluation Assurance Level 2 (Augmented)",
+                  "cc-eal3": "Common Criteria - Evaluation Assurance Level 3",
+                  "cc-eal3+": "Common Criteria - Evaluation Assurance Level 3 (Augmented)",
+                  "cc-eal4": "Common Criteria - Evaluation Assurance Level 4",
+                  "cc-eal4+": "Common Criteria - Evaluation Assurance Level 4 (Augmented)",
+                  "cc-eal5": "Common Criteria - Evaluation Assurance Level 5",
+                  "cc-eal5+": "Common Criteria - Evaluation Assurance Level 5 (Augmented)",
+                  "cc-eal6": "Common Criteria - Evaluation Assurance Level 6",
+                  "cc-eal6+": "Common Criteria - Evaluation Assurance Level 6 (Augmented)",
+                  "cc-eal7": "Common Criteria - Evaluation Assurance Level 7",
+                  "cc-eal7+": "Common Criteria - Evaluation Assurance Level 7 (Augmented)",
+                  "other": "Another certification",
+                  "unknown": "The certification level is not known"
+                }
+              }
+            },
+            "mode": {
+              "type": "string",
+              "title": "Mode",
+              "description": "The mode of operation in which the cryptographic algorithm (block cipher) is used.",
+              "enum": [
+                "cbc",
+                "ecb",
+                "ccm",
+                "gcm",
+                "cfb",
+                "ofb",
+                "ctr",
+                "other",
+                "unknown"
+              ],
+              "meta:enum": {
+                "cbc": "Cipher block chaining",
+                "ecb": "Electronic codebook",
+                "ccm": "Counter with cipher block chaining message authentication code",
+                "gcm": "Galois/counter",
+                "cfb": "Cipher feedback",
+                "ofb": "Output feedback",
+                "ctr": "Counter",
+                "other": "Another mode of operation",
+                "unknown": "The mode of operation is not known"
+              }
+            },
+            "padding": {
+              "type": "string",
+              "title": "Padding",
+              "description": "The padding scheme that is used for the cryptographic algorithm.",
+              "enum": [
+                "pkcs5",
+                "pkcs7",
+                "pkcs1v15",
+                "oaep",
+                "raw",
+                "other",
+                "unknown"
+              ],
+              "meta:enum": {
+                "pkcs5": "Public Key Cryptography Standard: Password-Based Cryptography",
+                "pkcs7": "Public Key Cryptography Standard: Cryptographic Message Syntax",
+                "pkcs1v15": "Public Key Cryptography Standard: RSA Cryptography v1.5",
+                "oaep": "Optimal asymmetric encryption padding",
+                "raw": "Raw",
+                "other": "Another padding scheme",
+                "unknown": "The padding scheme is not known"
+              }
+            },
+            "cryptoFunctions": {
+              "type": "array",
+              "title": "Cryptographic functions",
+              "description": "The cryptographic functions implemented by the cryptographic algorithm.",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "generate",
+                  "keygen",
+                  "encrypt",
+                  "decrypt",
+                  "digest",
+                  "tag",
+                  "keyderive",
+                  "sign",
+                  "verify",
+                  "encapsulate",
+                  "decapsulate",
+                  "other",
+                  "unknown"
+                ]
+              }
+            },
+            "classicalSecurityLevel": {
+              "type": "integer",
+              "title": "classical security level",
+              "description": "The classical security level that a cryptographic algorithm provides (in bits).",
+              "minimum": 0
+            },
+            "nistQuantumSecurityLevel": {
+              "type": "integer",
+              "title": "NIST security strength category",
+              "description": "The NIST security strength category as defined in https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/evaluation-criteria/security-(evaluation-criteria). A value of 0 indicates that none of the categories are met.",
+              "minimum": 0,
+              "maximum": 6
+            }
+          }
+        },
+        "certificateProperties": {
+          "type": "object",
+          "title": "Certificate Properties",
+          "description": "Properties for cryptographic assets of asset type 'certificate'",
+          "additionalProperties": false,
+          "properties": {
+            "serialNumber": {
+              "type": "string",
+              "title": "Serial Number",
+              "description": "The serial number is a unique identifier for the certificate issued by a CA."
+            },
+            "subjectName": {
+              "type": "string",
+              "title": "Subject Name",
+              "description": "The subject name for the certificate"
+            },
+            "issuerName": {
+              "type": "string",
+              "title": "Issuer Name",
+              "description": "The issuer name for the certificate"
+            },
+            "notValidBefore": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Not Valid Before",
+              "description": "The date and time according to ISO-8601 standard from which the certificate is valid"
+            },
+            "notValidAfter": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Not Valid After",
+              "description": "The date and time according to ISO-8601 standard from which the certificate is not valid anymore"
+            },
+            "signatureAlgorithmRef": {
+              "deprecated": true,
+              "$ref": "#/definitions/refType",
+              "title": "Algorithm Reference",
+              "description": "[DEPRECATED] This will be removed in a future version. Use `@.relatedCryptographicAssets` instead.\nThe bom-ref to signature algorithm used by the certificate"
+            },
+            "subjectPublicKeyRef": {
+              "deprecated": true,
+              "$ref": "#/definitions/refType",
+              "title": "Key reference",
+              "description": "[DEPRECATED] This will be removed in a future version. Use `@.relatedCryptographicAssets` instead.\nThe bom-ref to the public key of the subject"
+            },
+            "certificateFormat": {
+              "type": "string",
+              "title": "Certificate Format",
+              "description": "The format of the certificate",
+              "examples": [
+                "X.509",
+                "PEM",
+                "DER",
+                "CVC"
+              ]
+            },
+            "certificateExtension": {
+              "deprecated": true,
+              "type": "string",
+              "title": "Certificate File Extension",
+              "description": "[DEPRECATED] This will be removed in a future version. Use `@.certificateFileExtension` instead.\nThe file extension of the certificate",
+              "examples": [
+                "crt",
+                "pem",
+                "cer",
+                "der",
+                "p12"
+              ]
+            },
+            "certificateFileExtension": {
+              "type": "string",
+              "title": "Certificate File Extension",
+              "description": "The file extension of the certificate.",
+              "examples": [
+                "crt",
+                "pem",
+                "cer",
+                "der",
+                "p12"
+              ]
+            },
+            "fingerprint": {
+              "type": "object",
+              "$ref": "#/definitions/hash",
+              "title": "Certificate Fingerprint",
+              "description": "The fingerprint is a cryptographic hash of the certificate excluding it's signature."
+            },
+            "certificateState": {
+              "type": "array",
+              "title": "Certificate Lifecycle State",
+              "description": "The certificate lifecycle is a comprehensive process that manages digital certificates from their initial creation to eventual expiration or revocation. It typically involves several stages",
+              "items": {
+                "type": "object",
+                "title": "State",
+                "description": "The state of the certificate.",
+                "oneOf": [
+                  {
+                    "title": "Pre-Defined State",
+                    "required": [
+                      "state"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "state": {
+                        "type": "string",
+                        "title": "State",
+                        "description": "A pre-defined state in the certificate lifecycle.",
+                        "enum": [
+                          "pre-activation",
+                          "active",
+                          "suspended",
+                          "deactivated",
+                          "revoked",
+                          "destroyed"
+                        ],
+                        "meta:enum": {
+                          "pre-activation": "The certificate has been issued by the issuing certificate authority (CA) but has not been authorized for use.",
+                          "active": "The certificate may be used to cryptographically protect information, cryptographically process previously protected information, or both.",
+                          "deactivated": "Certificates in the deactivated state shall not be used to apply cryptographic protection but, in some cases, may be used to process cryptographically protected information.",
+                          "suspended": "The use of a certificate may be suspended for several possible reasons.",
+                          "revoked": "A revoked certificate is a digital certificate that has been invalidated by the issuing certificate authority (CA) before its scheduled expiration date.",
+                          "destroyed": "The certificate has been destroyed."
+                        }
+                      },
+                      "reason": {
+                        "type": "string",
+                        "title": "Reason",
+                        "description": "A reason for the certificate being in this state."
+                      }
+                    }
+                  },
+                  {
+                    "title": "Custom State",
+                    "required": [
+                      "name"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "title": "State",
+                        "description": "The name of the certificate lifecycle state."
+                      },
+                      "description": {
+                        "type": "string",
+                        "title": "Description",
+                        "description": "The description of the certificate lifecycle state."
+                      },
+                      "reason": {
+                        "type": "string",
+                        "title": "Reason",
+                        "description": "A reason for the certificate being in this state."
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "creationDate": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Creation Date",
+              "description": "The date and time (timestamp) when the certificate was created or pre-activated."
+            },
+            "activationDate": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Activation Date",
+              "description": "The date and time (timestamp) when the certificate was activated."
+            },
+            "deactivationDate": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Deactivation Date",
+              "description": "The date and time (timestamp) when the related certificate was deactivated."
+            },
+            "revocationDate": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Revocation Date",
+              "description": "The date and time (timestamp) when the certificate was revoked."
+            },
+            "destructionDate": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Destruction Date",
+              "description": "The date and time (timestamp) when the certificate was destroyed."
+            },
+            "certificateExtensions": {
+              "type": "array",
+              "title": "Certificate Extensions",
+              "description": "A certificate extension is a field that provides additional information about the certificate or its use. Extensions are used to convey additional information beyond the standard fields.",
+              "items": {
+                "type": "object",
+                "title": "Extension",
+                "description": "",
+                "oneOf": [
+                  {
+                    "title": "Common Extensions",
+                    "required": [
+                      "commonExtensionName",
+                      "commonExtensionValue"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "commonExtensionName": {
+                        "type": "string",
+                        "title": "name",
+                        "description": "The name of the extension.",
+                        "enum": [
+                          "basicConstraints",
+                          "keyUsage",
+                          "extendedKeyUsage",
+                          "subjectAlternativeName",
+                          "authorityKeyIdentifier",
+                          "subjectKeyIdentifier",
+                          "authorityInformationAccess",
+                          "certificatePolicies",
+                          "crlDistributionPoints",
+                          "signedCertificateTimestamp"
+                        ],
+                        "meta:enum": {
+                          "basicConstraints": "Specifies whether a certificate can be used as a CA certificate or not.",
+                          "keyUsage": "Specifies the allowed uses of the public key in the certificate.",
+                          "extendedKeyUsage": "Specifies additional purposes for which the public key can be used.",
+                          "subjectAlternativeName": "Allows inclusion of additional names to identify the entity associated with the certificate.",
+                          "authorityKeyIdentifier": "Identifies the public key of the CA that issued the certificate.",
+                          "subjectKeyIdentifier": "Identifies the public key associated with the entity the certificate was issued to.",
+                          "authorityInformationAccess": "Contains CA issuers and OCSP information.",
+                          "certificatePolicies": "Defines the policies under which the certificate was issued and can be used.",
+                          "crlDistributionPoints": "Contains one or more URLs where a Certificate Revocation List (CRL) can be obtained.",
+                          "signedCertificateTimestamp": "Shows that the certificate has been publicly logged, which helps prevent the issuance of rogue certificates by a CA. Log ID, timestamp and signature as proof."
+                        }
+                      },
+                      "commonExtensionValue": {
+                        "type": "string",
+                        "title": "Value",
+                        "description": "The value of the certificate extension."
+                      }
+                    }
+                  },
+                  {
+                    "title": "Custom Extensions",
+                    "description": "Custom extensions may convey application-specific or vendor-specific data not covered by standard extensions. The structure and semantics of custom extensions are typically defined outside of public standards. CycloneDX leverages properties to support this capability.",
+                    "required": [
+                      "customExtensionName"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "customExtensionName": {
+                        "type": "string",
+                        "title": "Name",
+                        "description": "The name for the custom certificate extension."
+                      },
+                      "customExtensionValue": {
+                        "type": "string",
+                        "title": "Value",
+                        "description": "The description of the custom certificate extension."
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "relatedCryptographicAssets": {
+              "$ref": "#/definitions/relatedCryptographicAssets",
+              "title": "Related Cryptographic Assets",
+              "description": "A list of cryptographic assets related to this component."
+            }
+          }
+        },
+        "relatedCryptoMaterialProperties": {
+          "type": "object",
+          "title": "Related Cryptographic Material Properties",
+          "description": "Properties for cryptographic assets of asset type: `related-crypto-material`",
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "title": "relatedCryptoMaterialType",
+              "description": "The type for the related cryptographic material",
+              "enum": [
+                "private-key",
+                "public-key",
+                "secret-key",
+                "key",
+                "ciphertext",
+                "signature",
+                "digest",
+                "initialization-vector",
+                "nonce",
+                "seed",
+                "salt",
+                "shared-secret",
+                "tag",
+                "additional-data",
+                "password",
+                "credential",
+                "token",
+                "other",
+                "unknown"
+              ],
+              "meta:enum": {
+                "private-key": "The confidential key of a key pair used in asymmetric cryptography.",
+                "public-key": "The non-confidential key of a key pair used in asymmetric cryptography.",
+                "secret-key": "A key used to encrypt and decrypt messages in symmetric cryptography.",
+                "key": "A piece of information, usually an octet string, which, when processed through a cryptographic algorithm, processes cryptographic data.",
+                "ciphertext": "The result of encryption performed on plaintext using an algorithm (or cipher).",
+                "signature": "A cryptographic value that is calculated from the data and a key known only by the signer.",
+                "digest": "The output of the hash function.",
+                "initialization-vector": "A fixed-size random or pseudo-random value used as an input parameter for cryptographic algorithms.",
+                "nonce": "A random or pseudo-random number that can only be used once in a cryptographic communication.",
+                "seed": "The input to a pseudo-random number generator. Different seeds generate different pseudo-random sequences.",
+                "salt": "A value used in a cryptographic process, usually to ensure that the results of computations for one instance cannot be reused by an attacker.",
+                "shared-secret": "A piece of data known only to the parties involved, in a secure communication.",
+                "tag": "A message authentication code (MAC), sometimes known as an authentication tag, is a short piece of information used for authenticating and integrity-checking a message.",
+                "additional-data": "An unspecified collection of data with relevance to cryptographic activity.",
+                "password": "A secret word, phrase, or sequence of characters used during authentication or authorization.",
+                "credential": "Establishes the identity of a party to communication, usually in the form of cryptographic keys or passwords.",
+                "token": "An object encapsulating a security identity.",
+                "other": "Another type of cryptographic asset.",
+                "unknown": "The type of cryptographic asset is not known."
+              }
+            },
+            "id": {
+              "type": "string",
+              "title": "ID",
+              "description": "The unique identifier for the related cryptographic material."
+            },
+            "state": {
+              "type": "string",
+              "title": "State",
+              "description": "The key state as defined by NIST SP 800-57.",
+              "enum": [
+                "pre-activation",
+                "active",
+                "suspended",
+                "deactivated",
+                "compromised",
+                "destroyed"
+              ]
+            },
+            "algorithmRef": {
+              "deprecated": true,
+              "$ref": "#/definitions/refType",
+              "title": "Algorithm Reference",
+              "description": "[DEPRECATED] Use `@.relatedCryptographicAssets` instead.\nThe bom-ref to the algorithm used to generate the related cryptographic material."
+            },
+            "creationDate": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Creation Date",
+              "description": "The date and time (timestamp) when the related cryptographic material was created."
+            },
+            "activationDate": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Activation Date",
+              "description": "The date and time (timestamp) when the related cryptographic material was activated."
+            },
+            "updateDate": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Update Date",
+              "description": "The date and time (timestamp) when the related cryptographic material was updated."
+            },
+            "expirationDate": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Expiration Date",
+              "description": "The date and time (timestamp) when the related cryptographic material expires."
+            },
+            "value": {
+              "type": "string",
+              "title": "Value",
+              "description": "The associated value of the cryptographic material."
+            },
+            "size": {
+              "type": "integer",
+              "title": "Size",
+              "description": "The size of the cryptographic asset (in bits)."
+            },
+            "format": {
+              "type": "string",
+              "title": "Format",
+              "description": "The format of the related cryptographic material (e.g. P8, PEM, DER)."
+            },
+            "securedBy": {
+              "$ref": "#/definitions/securedBy",
+              "title": "Secured By",
+              "description": "The mechanism by which the cryptographic asset is secured by."
+            },
+            "fingerprint": {
+              "type": "object",
+              "$ref": "#/definitions/hash",
+              "title": "Fingerprint",
+              "description": "The fingerprint is a cryptographic hash of the asset."
+            },
+            "relatedCryptographicAssets": {
+              "$ref": "#/definitions/relatedCryptographicAssets",
+              "title": "Related Cryptographic Assets",
+              "description": "A list of cryptographic assets related to this component."
+            }
+          }
+        },
+        "protocolProperties": {
+          "type": "object",
+          "title": "Protocol Properties",
+          "description": "Properties specific to cryptographic assets of type: `protocol`.",
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "title": "Type",
+              "description": "The concrete protocol type.",
+              "enum": [
+                "tls",
+                "ssh",
+                "ipsec",
+                "ike",
+                "sstp",
+                "wpa",
+                "dtls",
+                "quic",
+                "eap-aka",
+                "eap-aka-prime",
+                "prins",
+                "5g-aka",
+                "other",
+                "unknown"
+              ],
+              "meta:enum": {
+                "tls": "Transport Layer Security",
+                "ssh": "Secure Shell",
+                "ipsec": "Internet Protocol Security",
+                "ike": "Internet Key Exchange",
+                "sstp": "Secure Socket Tunneling Protocol",
+                "wpa": "Wi-Fi Protected Access",
+                "dtls": "Datagram Transport Layer Security",
+                "quic": "Quick UDP Internet Connections",
+                "eap-aka": "Extensible Authentication Protocol variant",
+                "eap-aka-prime": "Enhanced version of EAP-AKA",
+                "prins": "Protection of Inter-Network Signaling",
+                "5g-aka": "Authentication and Key Agreement for 5G",
+                "other": "Another protocol type",
+                "unknown": "The protocol type is not known"
+              }
+            },
+            "version": {
+              "type": "string",
+              "title": "Protocol Version",
+              "description": "The version of the protocol.",
+              "examples": [
+                "1.0",
+                "1.2",
+                "1.99"
+              ]
+            },
+            "cipherSuites": {
+              "type": "array",
+              "title": "Cipher Suites",
+              "description": "A list of cipher suites related to the protocol.",
+              "items": {
+                "$ref": "#/definitions/cipherSuite",
+                "title": "Cipher Suite"
+              }
+            },
+            "ikev2TransformTypes": {
+              "type": "object",
+              "title": "IKEv2 Transform Types",
+              "description": "The IKEv2 transform types supported (types 1-4), defined in [RFC 7296 section 3.3.2](https://www.ietf.org/rfc/rfc7296.html#section-3.3.2), and additional properties.",
+              "additionalProperties": false,
+              "properties": {
+                "encr": {
+                  "title": "Encryption Algorithms (ENCR)",
+                  "description": "Transform Type 1: encryption algorithms",
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "title": "Encryption Algorithms (ENCR)",
+                      "items": {
+                        "$ref": "#/definitions/ikeV2Enc",
+                        "title": "Encryption Algorithm (ENCR)"
+                      }
+                    },
+                    {
+                      "deprecated": true,
+                      "$ref": "#/definitions/cryptoRefArray",
+                      "title": "Encryption Algorithm (ENCR) References",
+                      "description": "[DEPRECATED] This will be removed in a future version.\nTransform Type 1: encryption algorithms"
+                    }
+                  ]
+                },
+                "prf": {
+                  "title": "Pseudorandom Functions (PRF)",
+                  "description": "Transform Type 2: pseudorandom functions",
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "title": "Pseudorandom Functions (PRF)",
+                      "items": {
+                        "$ref": "#/definitions/ikeV2Prf",
+                        "title": "Pseudorandom Function (PRF)"
+                      }
+                    },
+                    {
+                      "deprecated": true,
+                      "$ref": "#/definitions/cryptoRefArray",
+                      "description": "[DEPRECATED] This will be removed in a future version.\nTransform Type 2: pseudorandom functions"
+                    }
+                  ]
+                },
+                "integ": {
+                  "title": "Integrity Algorithms (INTEG)",
+                  "description": "Transform Type 3: integrity algorithms",
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "title": "Integrity Algorithms (INTEG)",
+                      "items": {
+                        "$ref": "#/definitions/ikeV2Integ",
+                        "title": "Integrity Algorithm (INTEG)"
+                      }
+                    },
+                    {
+                      "deprecated": true,
+                      "$ref": "#/definitions/cryptoRefArray",
+                      "description": "[DEPRECATED] This will be removed in a future version.\nTransform Type 3: integrity algorithms"
+                    }
+                  ]
+                },
+                "ke": {
+                  "title": "Key Exchange Methods (KE)",
+                  "description": "Transform Type 4: Key Exchange Method (KE) per [RFC 9370](https://www.ietf.org/rfc/rfc9370.html), formerly called Diffie-Hellman Group (D-H).",
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "title": "Key Exchange Methods (KE)",
+                      "items": {
+                        "$ref": "#/definitions/ikeV2Ke",
+                        "title": "Key Exchange Method (KE)"
+                      }
+                    },
+                    {
+                      "deprecated": true,
+                      "$ref": "#/definitions/cryptoRefArray",
+                      "description": "[DEPRECATED] This will be removed in a future version.\nTransform Type 4: Key Exchange Method (KE) per [RFC 9370](https://www.ietf.org/rfc/rfc9370.html), formerly called Diffie-Hellman Group (D-H)."
+                    }
+                  ]
+                },
+                "esn": {
+                  "type": "boolean",
+                  "title": "Extended Sequence Number (ESN)",
+                  "description": "Specifies if an Extended Sequence Number (ESN) is used."
+                },
+                "auth": {
+                  "title": "IKEv2 Authentication methods",
+                  "description": "IKEv2 Authentication method per [RFC9593](https://www.ietf.org/rfc/rfc9593.html).",
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "title": "IKEv2 Authentication Methods",
+                      "items": {
+                        "$ref": "#/definitions/ikeV2Auth",
+                        "title": "IKEv2 Authentication Method"
+                      }
+                    },
+                    {
+                      "deprecated": true,
+                      "$ref": "#/definitions/cryptoRefArray",
+                      "description": "[DEPRECATED] This will be removed in a future version.\nIKEv2 Authentication method"
+                    }
+                  ]
+                }
+              }
+            },
+            "cryptoRefArray": {
+              "deprecated": true,
+              "$ref": "#/definitions/cryptoRefArray",
+              "title": "Cryptographic References",
+              "description": "[DEPRECATED] Use `@.relatedCryptographicAssets` instead.\nA list of protocol-related cryptographic assets"
+            },
+            "relatedCryptographicAssets": {
+              "$ref": "#/definitions/relatedCryptographicAssets",
+              "title": "Related Cryptographic Assets",
+              "description": "A list of cryptographic assets related to this component."
+            }
+          }
+        },
+        "oid": {
+          "type": "string",
+          "title": "OID",
+          "description": "The object identifier (OID) of the cryptographic asset."
+        }
+      }
+    },
+    "cipherSuite": {
+      "type": "object",
+      "title": "Cipher Suite",
+      "description": "Object representing a cipher suite",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Common Name",
+          "description": "A common name for the cipher suite.",
+          "examples": [
+            "TLS_DHE_RSA_WITH_AES_128_CCM"
+          ]
+        },
+        "algorithms": {
+          "type": "array",
+          "title": "Related Algorithms",
+          "description": "A list of algorithms related to the cipher suite.",
+          "items": {
+            "$ref": "#/definitions/refType",
+            "title": "Algorithm reference",
+            "description": "The bom-ref to algorithm cryptographic asset."
+          }
+        },
+        "identifiers": {
+          "type": "array",
+          "title": "Cipher Suite Identifiers",
+          "description": "A list of common identifiers for the cipher suite.",
+          "items": {
+            "type": "string",
+            "title": "identifier",
+            "description": "Cipher suite identifier",
+            "examples": [
+              "0xC0",
+              "0x9E"
+            ]
+          }
+        },
+        "tlsGroups": {
+          "type": "array",
+          "title": "TLS Groups",
+          "description": "A list of TLS named groups (formerly known as curves) for this cipher suite. These groups define the parameters for key exchange algorithms like ECDHE.",
+          "items": {
+            "type": "string",
+            "title": "Group Name",
+            "description": "The name of the TLS group",
+            "examples": [
+              "x25519",
+              "ffdhe2048"
+            ]
+          }
+        },
+        "tlsSignatureSchemes": {
+          "type": "array",
+          "title": "TLS Signature Schemes",
+          "description": "A list of signature schemes supported for cipher suite. These schemes specify the algorithms used for digital signatures in TLS handshakes and certificate verification.",
+          "items": {
+            "type": "string",
+            "title": "Signature Scheme",
+            "description": "The name of the TLS signature scheme",
+            "examples": [
+              "ecdsa_secp256r1_sha256",
+              "rsa_pss_rsae_sha256",
+              "ed25519"
+            ]
+          }
+        }
+      }
+    },
+    "ikeV2Enc": {
+      "type": "object",
+      "title": "Encryption Algorithm (ENCR)",
+      "description": "Object representing an encryption algorithm (ENCR)",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "A name for the encryption method.",
+          "examples": [
+            "ENCR_AES_GCM_16"
+          ]
+        },
+        "keyLength": {
+          "type": "integer",
+          "title": "Encryption algorithm key length",
+          "description": "The key length of the encryption algorithm."
+        },
+        "algorithm": {
+          "$ref": "#/definitions/refType",
+          "title": "Algorithm reference",
+          "description": "The bom-ref to algorithm cryptographic asset."
+        }
+      }
+    },
+    "ikeV2Prf": {
+      "type": "object",
+      "title": "Pseudorandom Function (PRF)",
+      "description": "Object representing a pseudorandom function (PRF)",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "A name for the pseudorandom function.",
+          "examples": [
+            "PRF_HMAC_SHA2_256"
+          ]
+        },
+        "algorithm": {
+          "$ref": "#/definitions/refType",
+          "title": "Algorithm reference",
+          "description": "The bom-ref to algorithm cryptographic asset."
+        }
+      }
+    },
+    "ikeV2Integ": {
+      "type": "object",
+      "title": "Integrity Algorithm (INTEG)",
+      "description": "Object representing an integrity algorithm (INTEG)",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "A name for the integrity algorithm.",
+          "examples": [
+            "AUTH_HMAC_SHA2_256_128"
+          ]
+        },
+        "algorithm": {
+          "$ref": "#/definitions/refType",
+          "title": "Algorithm reference",
+          "description": "The bom-ref to algorithm cryptographic asset."
+        }
+      }
+    },
+    "ikeV2Ke": {
+      "type": "object",
+      "title": "Key Exchange Method (KE)",
+      "description": "Object representing a key exchange method (KE)",
+      "additionalProperties": false,
+      "properties": {
+        "group": {
+          "type": "integer",
+          "title": "Group Identifier",
+          "description": "A group identifier for the key exchange algorithm."
+        },
+        "algorithm": {
+          "$ref": "#/definitions/refType",
+          "title": "Algorithm reference",
+          "description": "The bom-ref to algorithm cryptographic asset."
+        }
+      }
+    },
+    "ikeV2Auth": {
+      "type": "object",
+      "title": "IKEv2 Authentication method",
+      "description": "Object representing a IKEv2 Authentication method",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "A name for the authentication method."
+        },
+        "algorithm": {
+          "$ref": "#/definitions/refType",
+          "title": "Algorithm reference",
+          "description": "The bom-ref to algorithm cryptographic asset."
+        }
+      }
+    },
+    "cryptoRefArray" : {
+      "deprecated": true,
+      "title": "Encryption Algorithm (ENCR) Reference Array",
+      "description": "Deprecated definition.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/refType"
+      }
+    },
+    "relatedCryptographicAssets": {
+      "type": "array",
+      "title": "Related Cryptographic Assets",
+      "description": "A list of cryptographic assets related to this component.",
+      "items": {
+        "$ref": "#/definitions/relatedCryptographicAsset",
+        "title": "Related Cryptographic Asset"
+      }
+    },
+    "relatedCryptographicAsset": {
+      "type": "object",
+      "title": "Related Cryptographic Asset",
+      "description": "A cryptographic assets related to this component.",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "title": "Type",
+          "description": "Specifies the mechanism by which the cryptographic asset is secured by.",
+          "examples": [
+            "publicKey",
+            "privateKey",
+            "algorithm"
+          ]
+        },
+        "ref": {
+          "$ref": "#/definitions/refType",
+          "title": "Reference to cryptographic asset",
+          "description": "The bom-ref to cryptographic asset."
+        }
+      }
+    },
+    "securedBy": {
+      "type": "object",
+      "title": "Secured By",
+      "description": "Specifies the mechanism by which the cryptographic asset is secured by",
+      "additionalProperties": false,
+      "properties": {
+        "mechanism": {
+          "type": "string",
+          "title": "Mechanism",
+          "description": "Specifies the mechanism by which the cryptographic asset is secured by.",
+          "examples": [
+            "HSM",
+            "TPM",
+            "SGX",
+            "Software",
+            "None"
+          ]
+        },
+        "algorithmRef": {
+          "$ref": "#/definitions/refType",
+          "title": "Algorithm Reference",
+          "description": "The bom-ref to the algorithm."
+        }
+      }
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "title": "Tags",
+      "description": "Textual strings that aid in discovery, search, and retrieval of the associated object. Tags often serve as a way to group or categorize similar or related objects by various attributes.",
+      "examples": [
+        "json-parser",
+        "object-persistence",
+        "text-to-image",
+        "translation",
+        "object-detection"
+      ]
+    },
+    "patentFamily": {
+      "type": "object",
+      "title": "Patent Family",
+      "description": "A patent family is a group of related patent applications or granted patents that cover the same or similar invention. These patents are filed in multiple jurisdictions to protect the invention across different regions or countries. A patent family typically includes patents that share a common priority date, originating from the same initial application, and may vary slightly in scope or claims to comply with regional legal frameworks. Fields align with WIPO ST.96 standards where applicable.",
+      "required": ["familyId"],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM. \n\nFor a patent, it might be a good idea to use a patent number as the BOM reference ID."
+        },
+        "familyId": {
+          "type": "string",
+          "title": "Patent Family ID",
+          "description": "The unique identifier for the patent family, aligned with the `id` attribute in WIPO ST.96 v8.0's `PatentFamilyType`. Refer to [PatentFamilyType in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/PatentFamilyType.xsd)."
+        },
+        "priorityApplication": {
+          "$ref": "#/definitions/priorityApplication"
+        },
+        "members": {
+          "type": "array",
+          "title": "Family Members",
+          "description": "A collection of patents or applications that belong to this family, each identified by a `bom-ref` pointing to a patent object defined elsewhere in the BOM.",
+          "items": {
+            "$ref": "#/definitions/refLinkType",
+            "title": "BOM Reference",
+            "description": "A `bom-ref` linking to a patent or application object within the BOM."
+          }
+        },
+        "externalReferences": {
+          "type": "array",
+          "title": "External References",
+          "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM.",
+          "items": {
+            "$ref": "#/definitions/externalReference"
+          }
+        }
+      }
+    },
+    "patent": {
+      "type": "object",
+      "title": "Patent",
+      "description": "A patent is a legal instrument, granted by an authority, that confers certain rights over an invention for a specified period, contingent on public disclosure and adherence to relevant legal requirements. The summary information in this object is aligned with [WIPO ST.96](https://www.wipo.int/standards/en/st96/) principles where applicable.",
+      "required": ["patentNumber", "jurisdiction", "patentLegalStatus"],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
+        },
+        "patentNumber": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9\\-/.()\\s]{0,28}[A-Za-z0-9]$",
+          "title": "Patent Number",
+          "description": "The unique number assigned to the granted patent by the issuing authority. Aligned with `PatentNumber` in WIPO ST.96. Refer to [PatentNumber in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/PatentNumber.xsd).",
+          "examples": ["US987654321", "EP1234567B1"]
+        },
+        "applicationNumber": {
+          "$ref": "#/definitions/patentApplicationNumber"
+        },
+        "jurisdiction": {
+          "$ref": "#/definitions/patentJurisdiction"
+        },
+        "priorityApplication": {
+          "$ref": "#/definitions/priorityApplication"
+        },
+        "publicationNumber": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9\\-/.()\\s]{0,28}[A-Za-z0-9]$",
+          "title": "Patent Publication Number",
+          "description": "This is the number assigned to a patent application once it is published. Patent applications are generally published 18 months after filing (unless an applicant requests non-publication). This number is distinct from the application number. \n\nPurpose: Identifies the publicly available version of the application. \n\nFormat: Varies by jurisdiction, often similar to application numbers but includes an additional suffix indicating publication. \n\nExample:\n - US: US20240000123A1 (indicates the first publication of application US20240000123) \n - Europe: EP23123456A1 (first publication of European application EP23123456). \n\nWIPO ST.96 v8.0: \n - Publication Number field: https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/PublicationNumber.xsd"
+        },
+        "title": {
+          "type": "string",
+          "title": "Patent Title",
+          "description": "The title of the patent, summarising the invention it protects. Aligned with `InventionTitle` in WIPO ST.96. Refer to [InventionTitle in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/InventionTitle.xsd)."
+        },
+        "abstract": {
+          "type": "string",
+          "title": "Patent Abstract",
+          "description": "A brief summary of the invention described in the patent. Aligned with `Abstract` and `P` in WIPO ST.96. Refer to [Abstract in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/Abstract.xsd)."
+        },
+        "filingDate": {
+          "type": "string",
+          "format": "date",
+          "title": "Filing Date",
+          "description": "The date the patent application was filed with the jurisdiction. Aligned with `FilingDate` in WIPO ST.96. Refer to [FilingDate in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/FilingDate.xsd)."
+        },
+        "grantDate": {
+          "type": "string",
+          "format": "date",
+          "title": "Grant Date",
+          "description": "The date the patent was granted by the jurisdiction. Aligned with `GrantDate` in WIPO ST.96. Refer to [GrantDate in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/GrantDate.xsd)."
+        },
+        "patentExpirationDate": {
+          "type": "string",
+          "format": "date",
+          "title": "Expiration Date",
+          "description": "The date the patent expires. Derived from grant or filing date according to jurisdiction-specific rules."
+        },
+        "patentLegalStatus": {
+          "type": "string",
+          "title": "Legal Status",
+          "description": "Indicates the current legal status of the patent or patent application, based on the WIPO ST.27 standard. This status reflects administrative, procedural, or legal events. Values include both active and inactive states and are useful for determining enforceability, procedural history, and maintenance status.",
+          "enum": [
+            "pending",
+            "granted",
+            "revoked",
+            "expired",
+            "lapsed",
+            "withdrawn",
+            "abandoned",
+            "suspended",
+            "reinstated",
+            "opposed",
+            "terminated",
+            "invalidated",
+            "in-force"
+          ],
+          "meta:enum": {
+            "pending": "The patent application has been filed but not yet examined or granted.",
+            "granted": "The patent application has been examined and a patent has been issued.",
+            "revoked": "The patent has been declared invalid through a legal or administrative process.",
+            "expired": "The patent has reached the end of its enforceable term.",
+            "lapsed": "The patent is no longer in force due to non-payment of maintenance fees or other requirements.",
+            "withdrawn": "The patent application was voluntarily withdrawn by the applicant.",
+            "abandoned": "The patent application was abandoned, often due to lack of action or response.",
+            "suspended": "Processing of the patent application has been temporarily halted.",
+            "reinstated": "A previously abandoned or lapsed patent has been reinstated.",
+            "opposed": "The patent application or granted patent is under formal opposition proceedings.",
+            "terminated": "The patent or application has been officially terminated.",
+            "invalidated": "The patent has been invalidated, either in part or in full.",
+            "in-force": "The granted patent is active and enforceable."
+          }
+        },
+        "patentAssignee": {
+          "type": "array",
+          "title": "Patent Assignees",
+          "description": "A collection of organisations or individuals to whom the patent rights are assigned. This supports joint ownership and allows for flexible representation of both corporate entities and individual inventors.",
+          "items": {
+            "oneOf": [
+              {
+                "title": "Person",
+                "$ref": "#/definitions/organizationalContact"
+              },
+              {
+                "title": "Organizational Entity",
+                "$ref": "#/definitions/organizationalEntity"
+              }
+            ]
+          }
+        },
+        "externalReferences": {
+          "type": "array",
+          "title": "External References",
+          "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM.",
+          "items": {
+            "$ref": "#/definitions/externalReference"
+          }
+        }
+      }
+    },
+    "patentAssertions": {
+      "type": "array",
+      "title": "Patent Assertions",
+      "description": "A list of assertions made regarding patents associated with this component or service. Assertions distinguish between ownership, licensing, and other relevant interactions with patents.",
+      "items": {
+        "type": "object",
+        "title": "Patent Assertion",
+        "description": "An assertion linking a patent or patent family to this component or service.",
+        "required": ["assertionType", "asserter"],
+        "additionalProperties": false,
+        "properties": {
+          "bom-ref": {
+            "$ref": "#/definitions/refType",
+            "title": "BOM Reference",
+            "description": "A reference to the patent or patent family object within the BOM. This must match the `bom-ref` of a `patent` or `patentFamily` object."
+          },
+          "assertionType": {
+            "type": "string",
+            "title": "Assertion Type",
+            "description": "The type of assertion being made about the patent or patent family. Examples include ownership, licensing, and standards inclusion.",
+            "enum": [
+              "ownership",
+              "license",
+              "third-party-claim",
+              "standards-inclusion",
+              "prior-art",
+              "exclusive-rights",
+              "non-assertion",
+              "research-or-evaluation"
+            ],
+            "meta:enum": {
+              "ownership": "The manufacturer asserts ownership of the patent or patent family.",
+              "license": "The manufacturer asserts they have a license to use the patent or patent family.",
+              "third-party-claim": "A third party has asserted a claim or potential infringement against the manufacturer’s component or service.",
+              "standards-inclusion": "The patent is part of a standard essential patent (SEP) portfolio relevant to the component or service.",
+              "prior-art": "The manufacturer asserts the patent or patent family as prior art that invalidates another patent or claim.",
+              "exclusive-rights": "The manufacturer asserts exclusive rights granted through a licensing agreement.",
+              "non-assertion": "The manufacturer asserts they will not enforce the patent or patent family against certain uses or users.",
+              "research-or-evaluation": "The patent or patent family is being used under a research or evaluation license."
+            }
+          },
+          "patentRefs": {
+            "type": "array",
+            "title": "Patent References",
+            "description": "A list of BOM references (`bom-ref`) linking to patents or patent families associated with this assertion.",
+            "items": {
+              "$ref": "#/definitions/refType"
+            }
+          },
+          "asserter": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/organizationalEntity",
+                "title": "Organizational Entity"
+              },
+              {
+                "$ref": "#/definitions/organizationalContact",
+                "title": "Person"
+              },
+              {
+                "$ref": "#/definitions/refLinkType",
+                "title": "Reference",
+                "description": "A reference to a previously defined `organizationalContact` or `organizationalEntity` object in the BOM. The value must be a valid `bom-ref` pointing to one of these objects."
+              }
+            ]
+          },
+          "notes": {
+            "type": "string",
+            "title": "Notes",
+            "description": "Additional notes or clarifications regarding the assertion, if necessary. For example, geographical restrictions, duration, or limitations of a license."
+          }
+        }
+      }
+    },
+    "patentApplicationNumber": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9\\-/.()\\s]{0,28}[A-Za-z0-9]$",
+      "title": "Patent Application Number",
+      "description": "The unique number assigned to a patent application when it is filed with a patent office. It is used to identify the specific application and track its progress through the examination process. Aligned with `ApplicationNumber` in ST.96. Refer to [ApplicationIdentificationType in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/ApplicationIdentificationType.xsd).",
+      "examples": ["US20240000123", "EP23123456"]
+    },
+    "patentJurisdiction": {
+      "type": "string",
+      "title": "Jurisdiction",
+      "description": "The jurisdiction or patent office where the priority application was filed, specified using WIPO ST.3 codes. Aligned with `IPOfficeCode` in ST.96. Refer to [IPOfficeCode in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Common/IPOfficeCode.xsd).",
+      "pattern": "^[A-Z]{2}$",
+      "examples": ["US", "EP", "JP"]
+    },
+    "patentFilingDate": {
+      "type": "string",
+      "format": "date",
+      "title": "Filing Date",
+      "description": "The date the priority application was filed, aligned with `FilingDate` in ST.96. Refer to [FilingDate in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/FilingDate.xsd)."
+    },
+    "priorityApplication": {
+      "type": "object",
+      "title": "Priority Application",
+      "description": "The priorityApplication contains the essential data necessary to identify and reference an earlier patent filing for priority rights. In line with WIPO ST.96 guidelines, it includes the jurisdiction (office code), application number, and filing date-the three key elements that uniquely specify the priority application in a global patent context.",
+      "required": ["applicationNumber", "jurisdiction", "filingDate"],
+      "additionalProperties": false,
+      "properties": {
+        "applicationNumber": {
+          "$ref": "#/definitions/patentApplicationNumber"
+        },
+        "jurisdiction": {
+          "$ref": "#/definitions/patentJurisdiction"
+        },
+        "filingDate": {
+          "$ref": "#/definitions/patentFilingDate"
+        }
+      }
+    },
+    "citation": {
+      "type": "object",
+      "title": "Citation",
+      "description": "Details a specific attribution of data within the BOM to a contributing entity or process.",
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference"
+        },
+        "pointers": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Field Reference",
+            "description": "A [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901) identifying the BOM field to which the attribution applies.\nUsers of other serialization formats (e.g. XML) shall use the JSON Pointer format to ensure consistent field referencing across representations."
+          },
+          "minItems": 1,
+          "title": "Field References",
+          "description": "One or more [JSON Pointers](https://datatracker.ietf.org/doc/html/rfc6901) identifying the BOM fields to which the attribution applies.\nExactly one of the \"pointers\" or \"expressions\" elements must be present."
+        },
+        "expressions": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Path Expression",
+            "description": "Specifies a path expression used to locate a value within a BOM. The expression syntax shall conform to the format of the BOM's serialization.\nUse [JSONPath](https://datatracker.ietf.org/doc/html/rfc9535) for JSON, [XPath](https://www.w3.org/TR/xpath/) for XML, and default to JSONPath for Protocol Buffers unless otherwise specified.\nImplementers shall ensure the expression is valid within the context of the applicable serialization format."
+          },
+          "minItems": 1,
+          "title": "Path Expressions",
+          "description": "One or more path expressions used to locate values within a BOM.\nExactly one of the \"pointers\" or \"expressions\" elements must be present."
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Timestamp",
+          "description": "The date and time when the attribution was made or the information was supplied."
+        },
+        "attributedTo": {
+          "$ref": "#/definitions/refLinkType",
+          "title": "Attributed To",
+          "description": "The `bom-ref` of an object, such as a component, service, tool, organisational entity, or person that supplied the cited information.\nAt least one of the \"attributedTo\" or \"process\" elements must be present."
+        },
+        "process": {
+          "$ref": "#/definitions/refLinkType",
+          "title": "Process Reference",
+          "description": "The `bom-ref` to a process (such as a formula, workflow, task, or step) defined in the `formulation` section that executed or generated the attributed data.\nAt least one of the \"attributedTo\" or \"process\" elements must be present."
+        },
+        "note": {
+          "type": "string",
+          "title": "Note",
+          "description": "A description or comment about the context or quality of the data attribution."
+        },
+        "signature": {
+          "$ref": "#/definitions/signature",
+          "title": "Signature",
+          "description": "A digital signature verifying the authenticity or integrity of the attribution."
+        }
+      },
+      "required": ["timestamp"],
+      "anyOf": [
+        { "required": ["attributedTo"] },
+        { "required": ["process"] }
+      ],
+      "oneOf": [
+        { "required": ["pointers"] },
+        { "required": ["expressions"] }
+      ]
+    }
+  }
+}

--- a/schema/bom-1.7.xsd
+++ b/schema/bom-1.7.xsd
@@ -1,0 +1,9742 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+CycloneDX Bill of Material (BOM) Specification
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning"
+           xmlns:bom="http://cyclonedx.org/schema/bom/1.7"
+           xmlns:spdx="http://cyclonedx.org/schema/spdx"
+           elementFormDefault="qualified"
+           targetNamespace="http://cyclonedx.org/schema/bom/1.7"
+           vc:minVersion="1.0"
+           vc:maxVersion="1.1"
+           version="1.7.0">
+
+    <xs:import namespace="http://cyclonedx.org/schema/spdx" schemaLocation="http://cyclonedx.org/schema/spdx"/>
+
+    <xs:annotation>
+        <xs:documentation>
+            <name>CycloneDX Bill of Materials Standard</name>
+            <url>https://cyclonedx.org/</url>
+            <license uri="http://www.apache.org/licenses/LICENSE-2.0"
+                     version="2.0">Apache License, Version 2.0</license>
+        </xs:documentation>
+    </xs:annotation>
+
+    <xs:simpleType name="refType">
+        <xs:annotation>
+            <xs:documentation>Identifier for referable and therefore interlink-able elements.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <!-- value SHOULD not start with the BOM-Link intro "urn:cdx:" -->
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="refLinkType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Descriptor for an element identified by the attribute "bom-ref" in the same BOM document.
+                In contrast to `bomLinkElementType`.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="bom:refType"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="versionType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en"><![CDATA[
+                A single disjunctive version identifier, for a component or service.
+
+                Example values:
+                - "9.0.14"
+                - "v1.33.7"
+                - "7.0.0-M1"
+                - "2.0pre1"
+                - "1.0.0-beta1"
+                - "0.8.15"
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:normalizedString">
+            <xs:maxLength value="1024"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="versionRangeType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en"><![CDATA[
+                A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/vers-spec
+
+                Example values:
+                - "vers:cargo/9.0.14"
+                - "vers:npm/1.2.3|>=2.0.0|<5.0.0"
+                - "vers:pypi/0.0.0|0.0.1|0.0.2|0.0.3|1.0|2.0pre1"
+                - "vers:tomee/>=1.0.0-beta1|<=1.7.5|>=7.0.0-M1|<=7.0.7|>=7.1.0|<=7.1.2|>=8.0.0-M1|<=8.0.1"
+                - "vers:gem/>=2.2.0|!= 2.2.1|<2.3.0"
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:normalizedString">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="4096"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="bomLinkDocumentType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Descriptor for another BOM document.
+                See https://cyclonedx.org/capabilities/bomlink/
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:anyURI">
+            <!-- part of the pattern is based on `bom.serialNumber`'s pattern -->
+            <xs:pattern value="urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="bomLinkElementType">
+        <xs:annotation>
+            <xs:documentation  xml:lang="en">
+                Descriptor for an element in another BOM document.
+                See https://cyclonedx.org/capabilities/bomlink/
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:anyURI">
+            <!-- part of the pattern is based on `bom.serialNumber`'s pattern -->
+            <xs:pattern value="urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*#.+"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="bomLinkType">
+        <xs:union memberTypes="bom:bomLinkDocumentType bom:bomLinkElementType"/>
+    </xs:simpleType>
+
+    <xs:complexType name="metadata">
+        <xs:sequence minOccurs="0" maxOccurs="1">
+            <xs:element name="timestamp" type="xs:dateTime" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>The date and time (timestamp) when the BOM was created.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="lifecycles" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Lifecycles communicate the stage(s) in which data in the BOM was captured. Different types of data may be available at various phases of a lifecycle, such as the Software Development Lifecycle (SDLC), IT Asset Management (ITAM), and Software Asset Management (SAM). Thus, a BOM may include data specific to or only obtainable in a given lifecycle.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="lifecycle" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:choice>
+                                    <xs:sequence>
+                                        <xs:element name="phase" type="bom:lifecyclePhaseType" minOccurs="1" maxOccurs="1">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    A pre-defined phase in the product lifecycle.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:element>
+                                    </xs:sequence>
+                                    <xs:sequence>
+                                        <xs:element name="name" type="xs:normalizedString" minOccurs="1" maxOccurs="1">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    The name of the lifecycle phase
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:element>
+                                        <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    The description of the lifecycle phase
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:element>
+                                    </xs:sequence>
+                                </xs:choice>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="tools" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The tool(s) used in the creation of the BOM.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:choice>
+                        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                            <xs:element name="tool" minOccurs="0" type="bom:toolType">
+                                <xs:annotation>
+                                    <xs:documentation>DEPRECATED. Use `../components` or `../services` instead.</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:sequence minOccurs="0" maxOccurs="1">
+                            <xs:element name="components" type="bom:componentsType" minOccurs="0" maxOccurs="1">
+                                <xs:annotation>
+                                    <xs:documentation>A list of software and hardware components used as tools.</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:element name="services" type="bom:servicesType" minOccurs="0" maxOccurs="1">
+                                <xs:annotation>
+                                    <xs:documentation>A list of services used as tools.</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="authors" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The person(s) who created the BOM.
+                        Authors are common in BOMs created through manual processes. BOMs created through automated means may have './manufacturer' instead.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="author" type="bom:organizationalContact"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="component" type="bom:component" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>The component that the BOM describes.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="manufacturer" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The organization that created the BOM.
+                        Manufacturer is common in BOMs created through automated processes. BOMs created through manual means may have './authors' instead.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="manufacture" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        DEPRECATED - DO NOT USE. This will be removed in a future version. Use the `./component/manufacturer` instead.
+                        The organization that manufactured the component that the BOM describes.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="supplier" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The organization that supplied the component that the BOM describes. The
+                        supplier may often be the manufacturer, but may also be a distributor or repackager.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="licenses" type="bom:licenseChoiceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The license information for the BOM document.
+                        This may be different from the license(s) of the component(s) that the BOM describes.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="distributionConstraints" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Conditions and constraints governing the sharing and distribution of the data or components
+                        described by this BOM.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="tlp" type="bom:tlpClassificationType" default="CLEAR" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The Traffic Light Protocol (TLP) classification that controls the sharing and
+                                    distribution of the data that the BOM describes.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##other" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:simpleType name="lifecyclePhaseType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="design">
+                <xs:annotation>
+                    <xs:documentation>
+                        BOM produced early in the development lifecycle containing inventory of components and services
+                        that are proposed or planned to be used. The inventory may need to be procured, retrieved,
+                        or resourced prior to use.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="pre-build">
+                <xs:annotation>
+                    <xs:documentation>
+                        BOM consisting of information obtained prior to a build process and may contain source files
+                        and development artifacts and manifests. The inventory may need to be resolved and retrieved
+                        prior to use.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="build">
+                <xs:annotation>
+                    <xs:documentation>
+                        BOM consisting of information obtained during a build process where component inventory is
+                        available for use. The precise versions of resolved components are usually available at this
+                        time as well as the provenance of where the components were retrieved from.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="post-build">
+                <xs:annotation>
+                    <xs:documentation>
+                        BOM consisting of information obtained after a build process has completed and the resulting
+                        components(s) are available for further analysis. Built components may exist as the result of a
+                        CI/CD process, may have been installed or deployed to a system or device, and may need to be
+                        retrieved or extracted from the system or device.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="operations">
+                <xs:annotation>
+                    <xs:documentation>
+                        BOM produced that represents inventory that is running and operational. This may include staging
+                        or production environments and will generally encompass multiple SBOMs describing the applications
+                        and operating system, along with HBOMs describing the hardware that makes up the system. Operations
+                        Bill of Materials (OBOM) can provide full-stack inventory of runtime environments, configurations,
+                        and additional dependencies.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="discovery">
+                <xs:annotation>
+                    <xs:documentation>
+                        BOM consisting of information observed through network discovery providing point-in-time
+                        enumeration of embedded, on-premise, and cloud-native services such as server applications,
+                        connected devices, microservices, and serverless functions.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="decommission">
+                <xs:annotation>
+                    <xs:documentation>
+                        BOM containing inventory that will be, or has been retired from operations.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="organizationalEntity">
+        <xs:sequence minOccurs="0" maxOccurs="1">
+            <xs:element name="name" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The name of the organization</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="address" type="bom:postalAddressType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The physical address (location) of the organization.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        The URL of the organization. Multiple URLs are allowed.
+                        Example: https://example.com
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="contact" type="bom:organizationalContact" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>A contact person at the organization. Multiple contacts are allowed.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An identifier which can be used to reference the object elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##other" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:simpleType name="tlpClassificationType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Traffic Light Protocol (TLP) is a classification system for identifying the potential risk associated with artefact, including whether it is subject to certain types of legal, financial, or technical threats. Refer to https://www.first.org/tlp/ for further information.
+                The default classification is "CLEAR"
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="CLEAR">
+                <xs:annotation>
+                    <xs:documentation>
+                        The information is not subject to any restrictions as regards the sharing.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GREEN">
+                <xs:annotation>
+                    <xs:documentation>
+                        The information is subject to limited disclosure, and recipients can share it within their community but not via publicly accessible channels.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="AMBER">
+                <xs:annotation>
+                    <xs:documentation>
+                        The information is subject to limited disclosure, and recipients can only share it on a need-to-know basis within their organization and with clients.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="AMBER_AND_STRICT">
+                <xs:annotation>
+                    <xs:documentation>
+                        The information is subject to limited disclosure, and recipients can only share it on a need-to-know basis within their organization.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="RED">
+                <xs:annotation>
+                    <xs:documentation>
+                        The information is subject to restricted distribution to individual recipients only and must not be shared.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+         </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="toolType">
+        <xs:annotation>
+            <xs:documentation>Information about the automated or manual tool used</xs:documentation>
+        </xs:annotation>
+        <xs:sequence minOccurs="0" maxOccurs="1">
+            <xs:element name="vendor" minOccurs="0" maxOccurs="1" type="xs:normalizedString">
+                <xs:annotation>
+                    <xs:documentation>The name of the vendor who created the tool</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:normalizedString">
+                <xs:annotation>
+                    <xs:documentation>The name of the tool</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="version" minOccurs="0" maxOccurs="1" type="bom:versionType">
+                <xs:annotation>
+                    <xs:documentation>The version of the tool</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="hashes" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="hash" type="bom:hashType"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="externalReferences" type="bom:externalReferences" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document external references related to the tool.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##other" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="organizationalContact">
+        <xs:sequence minOccurs="0" maxOccurs="1">
+            <xs:element name="name" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The name of the contact</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="email" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The email address of the contact.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="phone" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The phone number of the contact.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An identifier which can be used to reference the object elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##other" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="componentsType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="component" type="bom:component"/>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="component">
+        <xs:sequence>
+            <xs:element name="supplier" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The organization that supplied the component. The supplier may often
+                        be the manufacturer, but may also be a distributor or repackager.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="manufacturer" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The organization that created the component.
+                        Manufacturer is common in components created through automated processes. Components created through manual means may have './authors' instead.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="authors" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The person(s) who created the component.
+                        Authors are common in components created through manual processes. Components created through automated means may have `./manufacturer` instead.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="author" type="bom:organizationalContact"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="author" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        DEPRECATED - DO NOT USE. This will be removed in a future version. Use `./authors` or `./manufacturer` instead.
+                        The person(s) or organization(s) that authored the component.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="publisher" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The person(s) or organization(s) that published the component</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="group" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The grouping name or identifier. This will often be a shortened, single
+                        name of the company or project that produced the component, or the source package or
+                        domain name. Whitespace and special characters should be avoided. Examples include:
+                        apache, org.apache.commons, and apache.org.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" type="xs:normalizedString" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The name of the component. This will often be a shortened, single name
+                        of the component. Examples: commons-lang3 and jquery</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:choice minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Must be used exclusively, either 'version' or 'versionRange', but not both.</xs:documentation>
+                </xs:annotation>
+                <xs:element name="version" type="bom:versionType">
+                    <xs:annotation>
+                        <xs:documentation>The component version. The version should ideally comply with semantic versioning
+                            but is not enforced.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="versionRange" type="bom:versionRangeType">
+                    <xs:annotation>
+                        <xs:documentation><![CDATA[
+                        For an external component, this specifies the accepted version range.
+                        The value must adhere to the Package URL Version Range syntax (vers), as defined at https://github.com/package-url/vers-spec.
+                        May only be used if `@isExternal` is set to `true`.
+                        ]]></xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
+            <xs:element name="description" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Specifies a description for the component</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="scope" type="bom:scope" minOccurs="0" maxOccurs="1" default="required">
+                <xs:annotation>
+                    <xs:documentation>Specifies the scope of the component. If scope is not specified, 'required'
+                        scope SHOULD be assumed by the consumer of the BOM.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="hashes" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The hashes of the component.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="hash" type="bom:hashType"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="licenses" type="bom:licenseChoiceType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="copyright" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A copyright notice informing users of the underlying claims to copyright ownership in a published work.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="patentAssertions" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A list of assertions made regarding patents associated with this component or service. Assertions distinguish between ownership, licensing, and other relevant interactions with patents.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="patentAssertion" type="bom:patentAssertionType"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="cpe" type="bom:cpe" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Specifies a well-formed CPE name that conforms to the CPE 2.2 or 2.3 specification. See https://nvd.nist.gov/products/cpe
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="purl" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Specifies the package-url (purl). The purl, if specified, must be valid and conform
+                        to the specification defined at: https://github.com/package-url/purl-spec
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="omniborId" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Specifies the OmniBOR Artifact ID. The OmniBOR, if specified, must be valid and conform
+                        to the specification defined at: https://www.iana.org/assignments/uri-schemes/prov/gitoid
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="swhid" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Specifies the Software Heritage persistent identifier (SWHID). The SWHID, if specified, must
+                        be valid and conform to the specification defined at:
+                        https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="swid" type="bom:swidType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Specifies metadata and content for ISO-IEC 19770-2 Software Identification (SWID) Tags.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="modified" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        DEPRECATED - DO NOT USE. This will be removed in a future version. Use the pedigree
+                        element instead to supply information on exactly how the component was modified.
+                        A boolean value indicating if the component has been modified from the original.
+                        A value of true indicates the component is a derivative of the original.
+                        A value of false indicates the component has not been modified from the original.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="pedigree" type="bom:pedigreeType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Component pedigree is a way to document complex supply chain scenarios where components are
+                        created, distributed, modified, redistributed, combined with other components, etc.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="externalReferences" type="bom:externalReferences" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document external references related to the
+                        component or to the project the component describes.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="components" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A list of software and hardware components included in the parent component. This is not a
+                        dependency tree. It provides a way to specify a hierarchical representation of component
+                        assemblies, similar to system -> subsystem -> parts assembly in physical supply chains.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="component" type="bom:component"/>
+                        <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:any>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="evidence" type="bom:componentEvidenceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document evidence collected through various forms of extraction or analysis.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="releaseNotes" type="bom:releaseNotesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Specifies release notes.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="modelCard" type="bom:modelCardType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A model card describes the intended uses of a machine learning model and potential
+                        limitations, including biases and ethical considerations. Model cards typically contain the
+                        training parameters, which datasets were used to train the model, performance metrics, and other
+                        relevant data useful for ML transparency. This object SHOULD be specified for any component of
+                        type `machine-learning-model` and must not be specified for other component types.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="data" type="bom:componentDataType" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>This object SHOULD be specified for any component of type `data` and must not be
+                        specified for other component types.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="cryptoProperties" type="bom:cryptoPropertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Cryptographic assets have properties that uniquely define them and that make them actionable
+                        for further reasoning. As an example, it makes a difference if one knows the algorithm family
+                        (e.g. AES) or the specific variant or instantiation (e.g. AES-128-GCM). This is because the
+                        security level and the algorithm primitive (authenticated encryption) is only defined by the
+                        definition of the algorithm variant. The presence of a weak cryptographic algorithm like SHA1
+                        vs. HMAC-SHA1 also makes a difference.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="tags" type="bom:tagsType" minOccurs="0" maxOccurs="1" />
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="type" type="bom:classification" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies the type of component. For software components, classify as application if no more
+                    specific appropriate classification is available or cannot be determined for the component.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="mime-type" type="bom:mimeType">
+            <xs:annotation>
+                <xs:documentation>
+                    The mime-type of the component. When used on file components, the mime-type
+                    can provide additional context about the kind of file being represented such as an image,
+                    font, or executable. Some library or framework components may also have an associated mime-type.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="isExternal" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Determine whether this component is external.
+                    An external component is one that is not part of an assembly, but is expected to be provided by the environment, regardless of the component's `@scope`. This setting can be useful for distinguishing which components are bundled with the product and which can be relied upon to be present in the deployment environment.
+                    This may be set to `true` for runtime components only. For `/metadata/component`, it must be set to `false`.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An identifier which can be used to reference the component elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+        <!-- Attention:
+        This would be formal, if the support for XSD1.1's `assert` was properly implemented in validators and tools digesting XML.
+        <xs:assert vc:minVersion="1.1"
+                   id="versionRange_requires_isExternal_eq_true"
+                   test="if (versionRange) then (@isExternal eq 'true') else true()">
+            Child `versionRange` May only be present, if attribute `isExternal`=='true'.
+        </xs:assert>
+        -->
+    </xs:complexType>
+
+    <xs:attributeGroup name="licenseAttributes">
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An identifier which can be used to reference the license elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="acknowledgement" type="bom:licenseAcknowledgementEnumerationType">
+            <xs:annotation>
+                <xs:documentation>
+                    Declared licenses and concluded licenses represent two different stages in the
+                    licensing process within software development. Declared licenses refer to the
+                    initial intention of the software authors regarding the licensing terms under
+                    which their code is released. On the other hand, concluded licenses are the
+                    result of a comprehensive analysis of the project's codebase to identify and
+                    confirm the actual licenses of the components used, which may differ from the
+                    initially declared licenses. While declared licenses provide an upfront indication
+                    of the licensing intentions, concluded licenses offer a more thorough understanding
+                    of the actual licensing within a project, facilitating proper compliance and risk
+                    management. Observed licenses are defined in `evidence.licenses`. Observed licenses
+                    form the evidence necessary to substantiate a concluded license.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+
+    <xs:complexType name="licensingType">
+        <xs:sequence>
+            <xs:element name="altIds" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>License identifiers that may be used to manage licenses and
+                        their lifecycle</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="altId" type="xs:normalizedString" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="licensor" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The individual or organization that grants a license to another
+                        individual or organization</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:choice>
+                            <xs:element name="organization" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                                <xs:annotation>
+                                    <xs:documentation>The organization that granted the license</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:element name="individual" type="bom:organizationalContact" minOccurs="0" maxOccurs="1">
+                                <xs:annotation>
+                                    <xs:documentation>The individual, not associated with an organization,
+                                        that granted the license</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                        </xs:choice>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="licensee" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The individual or organization for which a license was granted to</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:choice>
+                            <xs:element name="organization" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                                <xs:annotation>
+                                    <xs:documentation>The organization that was granted the license</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:element name="individual" type="bom:organizationalContact" minOccurs="0" maxOccurs="1">
+                                <xs:annotation>
+                                    <xs:documentation>The individual, not associated with an organization,
+                                        that was granted the license</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                        </xs:choice>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="purchaser" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The individual or organization that purchased the license</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:choice>
+                            <xs:element name="organization" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                                <xs:annotation>
+                                    <xs:documentation>The organization that purchased the license</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:element name="individual" type="bom:organizationalContact" minOccurs="0" maxOccurs="1">
+                                <xs:annotation>
+                                    <xs:documentation>The individual, not associated with an organization,
+                                        that purchased the license</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                        </xs:choice>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="purchaseOrder" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The purchase order identifier the purchaser sent to a supplier or
+                        vendor to authorize a purchase</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="licenseTypes" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The type of license(s) that was granted to the licensee</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="licenseType" type="bom:licenseTypeEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="lastRenewal" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The timestamp indicating when the license was last
+                        renewed. For new purchases, this is often the purchase or acquisition date.
+                        For non-perpetual licenses or subscriptions, this is the timestamp of when the
+                        license was last renewed.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="expiration" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The timestamp indicating when the current license
+                        expires (if applicable).</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="licenseType">
+        <xs:annotation>
+            <xs:documentation>Specifies the details and attributes related to a software license.
+                It can either include a valid SPDX license identifier or a named license, along with additional
+                properties such as license acknowledgment, comprehensive commercial licensing information, and
+                the full text of the license.</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:choice>
+                <xs:element name="id" type="spdx:licenseId" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>A valid SPDX license identifier. If specified, this value must be one of the enumeration of valid SPDX license identifiers defined in the spdx.schema.json (or spdx.xml) subschema which is synchronized with the official SPDX license list.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="name" type="xs:normalizedString" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>The name of the license. This may include the name of a commercial or proprietary license or an open source license that may not be defined by SPDX.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
+            <xs:element name="text" type="bom:attachedTextType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Specifies the full text of the attachment</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The URL to the attachment file. If the attachment is a license or BOM,
+                        an externalReference should also be specified for completeness.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="licensing" type="bom:licensingType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Licensing details describing the licensor/licensee, license type, renewal and
+                        expiration dates, and other important metadata</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attributeGroup ref="bom:licenseAttributes"/>
+    </xs:complexType>
+
+    <xs:complexType name="licenseExpressionType">
+        <xs:simpleContent>
+            <xs:extension base="xs:normalizedString">
+                <xs:annotation>
+                    <xs:documentation>A valid SPDX license expression.
+                        Refer to https://spdx.org/specifications for syntax requirements.
+
+                        Example values:
+                        - Apache-2.0 AND (MIT OR GPL-2.0-only)
+                        - GPL-3.0-only WITH Classpath-exception-2.0
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:attributeGroup ref="bom:licenseAttributes"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="licenseExpressionDetailedType">
+        <xs:annotation>
+            <xs:documentation>
+                Specifies the details and attributes related to a software license.
+                It must be a valid SPDX license expression, along with additional properties such as license acknowledgment.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="details" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>Details for parts of the `expression`.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:annotation>
+                        <xs:documentation>
+                            This document specifies the details and attributes related to a software license identifier. An SPDX expression may be a compound of license identifiers.
+                            The `license-identifier` attribute serves as the key that identifies each record. Note that this key is not required to be unique, as the same license identifier could apply to multiple, different but similar license details, texts, etc.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:sequence>
+                        <xs:element name="text" type="bom:attachedTextType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>A way to include the textual content of the license.</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>The URL to the attachment file. If the attachment is a license or BOM,
+                                    an externalReference should also be specified for completeness.</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:any>
+                    </xs:sequence>
+                    <xs:attribute name="license-identifier" type="xs:normalizedString" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                A valid SPDX license identifier. Refer to https://spdx.org/specifications for syntax requirements.
+                                This attribute serves as the primary key, which uniquely identifies each record.
+
+                                Example values:
+                                - Apache-2.0
+                                - GPL-3.0-only WITH Classpath-exception-2.0
+                                - LicenseRef-my-custom-license
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="bom-ref" type="bom:refType">
+                        <xs:annotation>
+                            <xs:documentation>
+                                An identifier which can be used to reference the license elsewhere in the BOM.
+                                Uniqueness is enforced within all elements and children of the root-level bom element.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="licensing" type="bom:licensingType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Licensing details describing the licensor/licensee, license type, renewal and
+                        expiration dates, and other important metadata</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attributeGroup ref="bom:licenseAttributes"/>
+        <xs:attribute name="expression" type="xs:normalizedString" use="required">
+            <xs:annotation>
+                <xs:documentation>A valid SPDX license expression.
+                    Refer to https://spdx.org/specifications for syntax requirements.
+
+                    Example values:
+                    - Apache-2.0 AND (MIT OR GPL-2.0-only)
+                    - GPL-3.0-only WITH Classpath-exception-2.0
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="attachedTextType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:annotation>
+                    <xs:documentation>The attachment data. Proactive controls such as input validation and sanitization should be employed to prevent misuse of attachment text.</xs:documentation>
+                </xs:annotation>
+                <xs:attribute name="content-type" type="xs:normalizedString" default="text/plain">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Specifies the format and nature of the data being attached, helping systems correctly
+                            interpret and process the content. Common content type examples include `application/json`
+                            for JSON data and `text/plain` for plan text documents.
+                            RFC 2045 section 5.1 outlines the structure and use of content types. For a comprehensive
+                            list of registered content types, refer to the IANA media types registry at
+                            https://www.iana.org/assignments/media-types/media-types.xhtml.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="encoding" type="bom:encoding">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Specifies the encoding the text is represented in
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="hashType">
+        <xs:annotation>
+            <xs:documentation>Specifies the file hash of the component</xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="bom:hashValue">
+                <xs:attribute name="alg" type="bom:hashAlg" use="required">
+                    <xs:annotation>
+                        <xs:documentation>Specifies the algorithm used to create the hash</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:simpleType name="scope">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="required">
+                <xs:annotation>
+                    <xs:documentation>The component is required for runtime</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="optional">
+                <xs:annotation>
+                    <xs:documentation>The component is optional at runtime. Optional components are components that
+                        are not capable of being called due to them not be installed or otherwise accessible by any means.
+                        Components that are installed but due to configuration or other restrictions are prohibited from
+                        being called must be scoped as 'required'.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="excluded">
+                <xs:annotation>
+                    <xs:documentation>Components that are excluded provide the ability to document component usage
+                        for test and other non-runtime purposes. Excluded components are not reachable within a call
+                        graph at runtime.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="classification">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="application">
+                <xs:annotation>
+                    <xs:documentation>A software application. Refer to https://en.wikipedia.org/wiki/Application_software
+                        for information about applications.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="framework">
+                <xs:annotation>
+                    <xs:documentation>A software framework. Refer to https://en.wikipedia.org/wiki/Software_framework
+                        for information on how frameworks vary slightly from libraries.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="library">
+                <xs:annotation>
+                    <xs:documentation>A software library. Refer to https://en.wikipedia.org/wiki/Library_(computing)
+                        for information about libraries. All third-party and open source reusable components will likely
+                        be a library. If the library also has key features of a framework, then it should be classified
+                        as a framework. If not, or is unknown, then specifying library is recommended.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="container">
+                <xs:annotation>
+                    <xs:documentation>A packaging and/or runtime format, not specific to any particular technology,
+                        which isolates software inside the container from software outside of a container through
+                        virtualization technology. Refer to https://en.wikipedia.org/wiki/OS-level_virtualization</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="platform">
+                <xs:annotation>
+                    <xs:documentation>
+                        A runtime environment that interprets or executes software.
+                        This may include runtimes such as those that execute bytecode, just-in-time compilers,
+                        interpreters, or low-code/no-code application platforms.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="operating-system">
+                <xs:annotation>
+                    <xs:documentation>A software operating system without regard to deployment model
+                        (i.e. installed on physical hardware, virtual machine, image, etc) Refer to
+                        https://en.wikipedia.org/wiki/Operating_system</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="device">
+                <xs:annotation>
+                    <xs:documentation>A hardware device such as a processor, or chip-set. A hardware device
+                        containing firmware SHOULD include a component for the physical hardware itself, and another
+                        component of type 'firmware' or 'operating-system' (whichever is relevant), describing
+                        information about the software running on the device.
+                        See also the list of known device properties: https://github.com/CycloneDX/cyclonedx-property-taxonomy/blob/main/cdx/device.md
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="device-driver">
+                <xs:annotation>
+                    <xs:documentation>A special type of software that operates or controls a particular type of device.
+                        Refer to https://en.wikipedia.org/wiki/Device_driver</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="firmware">
+                <xs:annotation>
+                    <xs:documentation>A special type of software that provides low-level control over a devices
+                        hardware. Refer to https://en.wikipedia.org/wiki/Firmware</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="file">
+                <xs:annotation>
+                    <xs:documentation>A computer file. Refer to https://en.wikipedia.org/wiki/Computer_file
+                        for information about files.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="machine-learning-model">
+                <xs:annotation>
+                    <xs:documentation>A model based on training data that can make predictions or decisions without
+                        being explicitly programmed to do so.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="data">
+                <xs:annotation>
+                    <xs:documentation>A collection of discrete values that convey information.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="cryptographic-asset">
+                <xs:annotation>
+                    <xs:documentation>A cryptographic asset including algorithms, protocols, certificates, keys, tokens, and secrets.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="hashAlg">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="MD5"/>
+            <xs:enumeration value="SHA-1"/>
+            <xs:enumeration value="SHA-256"/>
+            <xs:enumeration value="SHA-384"/>
+            <xs:enumeration value="SHA-512"/>
+            <xs:enumeration value="SHA3-256"/>
+            <xs:enumeration value="SHA3-384"/>
+            <xs:enumeration value="SHA3-512"/>
+            <xs:enumeration value="BLAKE2b-256"/>
+            <xs:enumeration value="BLAKE2b-384"/>
+            <xs:enumeration value="BLAKE2b-512"/>
+            <xs:enumeration value="BLAKE3"/>
+            <xs:enumeration value="Streebog-256"/>
+            <xs:enumeration value="Streebog-512"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="licenseTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="academic">
+                <xs:annotation>
+                    <xs:documentation>A license that grants use of software solely for the purpose
+                        of education or research.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="appliance">
+                <xs:annotation>
+                    <xs:documentation>A license covering use of software embedded in a specific
+                        piece of hardware.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="client-access">
+                <xs:annotation>
+                    <xs:documentation>A Client Access License (CAL) allows client computers to access
+                        services provided by server software.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="concurrent-user">
+                <xs:annotation>
+                    <xs:documentation>A Concurrent User license (aka floating license) limits the
+                        number of licenses for a software application and licenses are shared among
+                        a larger number of users.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="core-points">
+                <xs:annotation>
+                    <xs:documentation>A license where the core of a computer's processor is assigned
+                        a specific number of points.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="custom-metric">
+                <xs:annotation>
+                    <xs:documentation>A license for which consumption is measured by non-standard
+                        metrics.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="device">
+                <xs:annotation>
+                    <xs:documentation>A license that covers a defined number of installations on
+                        computers and other types of devices.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="evaluation">
+                <xs:annotation>
+                    <xs:documentation>A license that grants permission to install and use software
+                        for trial purposes.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="named-user">
+                <xs:annotation>
+                    <xs:documentation>A license that grants access to the software to one or more
+                        pre-defined users.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="node-locked">
+                <xs:annotation>
+                    <xs:documentation>A license that grants access to the software on one or more
+                        pre-defined computers or devices.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="oem">
+                <xs:annotation>
+                    <xs:documentation>An Original Equipment Manufacturer license that is delivered
+                        with hardware, cannot be transferred to other hardware, and is valid for the
+                        life of the hardware.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="perpetual">
+                <xs:annotation>
+                    <xs:documentation>A license where the software is sold on a one-time basis and
+                        the licensee can use a copy of the software indefinitely.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="processor-points">
+                <xs:annotation>
+                    <xs:documentation>A license where each installation consumes points per
+                        processor.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="subscription">
+                <xs:annotation>
+                    <xs:documentation>A license where the licensee pays a fee to use the software
+                        or service.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="user">
+                <xs:annotation>
+                    <xs:documentation>A license that grants access to the software or service by a
+                        specified number of users.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="other">
+                <xs:annotation>
+                    <xs:documentation>Another license type.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="hashValue">
+        <xs:restriction base="xs:token">
+            <xs:pattern value="([a-fA-F0-9]{32})|([a-fA-F0-9]{40})|([a-fA-F0-9]{64})|([a-fA-F0-9]{96})|([a-fA-F0-9]{128})"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="mimeType">
+        <xs:restriction base="xs:token">
+            <xs:pattern value="[-+a-z0-9.]+/[-+a-z0-9.]+"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="encoding">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="base64"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="cpe">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Define the format for acceptable CPE URIs. Supports CPE 2.2 and CPE 2.3 formats.
+                Refer to https://nvd.nist.gov/products/cpe for official specification.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="([c][pP][eE]:/[AHOaho]?(:[A-Za-z0-9\._\-~%]*){0,6})|(cpe:2\.3:[aho\*\-](:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!&quot;#$$%&amp;'\(\)\+,/:;&lt;=&gt;@\[\]\^`\{\|}~]))+(\?*|\*?))|[\*\-])){5}(:(([a-zA-Z]{2,3}(-([a-zA-Z]{2}|[0-9]{3}))?)|[\*\-]))(:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!&quot;#$$%&amp;'\(\)\+,/:;&lt;=&gt;@\[\]\^`\{\|}~]))+(\?*|\*?))|[\*\-])){4})"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="swidType">
+        <xs:sequence>
+            <xs:element name="text" type="bom:attachedTextType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Specifies the full content of the SWID tag.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The URL to the SWID file.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="tagId" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>Maps to the tagId of a SoftwareIdentity.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>Maps to the name of a SoftwareIdentity.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="version" type="xs:string" use="optional" default="0.0">
+            <xs:annotation>
+                <xs:documentation>Maps to the version of a SoftwareIdentity.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="tagVersion" type="xs:integer" use="optional" default="0">
+            <xs:annotation>
+                <xs:documentation>Maps to the tagVersion of a SoftwareIdentity.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="patch" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>Maps to the patch of a SoftwareIdentity.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="urnUuid">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Defines a string representation of a UUID conforming to RFC 4122.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="urn:uuid:([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})|(\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\})"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="externalReferenceType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="vcs">
+                <xs:annotation>
+                    <xs:documentation>Version Control System</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="issue-tracker">
+                <xs:annotation>
+                    <xs:documentation>Issue or defect tracking system, or an Application Lifecycle Management (ALM) system</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="website">
+                <xs:annotation>
+                    <xs:documentation>Website</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="advisories">
+                <xs:annotation>
+                    <xs:documentation>Security advisories</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="bom">
+                <xs:annotation>
+                    <xs:documentation>Bill-of-materials (SBOM, OBOM, HBOM, SaaSBOM, etc)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="mailing-list">
+                <xs:annotation>
+                    <xs:documentation>Mailing list or discussion group</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="social">
+                <xs:annotation>
+                    <xs:documentation>Social media account</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="chat">
+                <xs:annotation>
+                    <xs:documentation>Real-time chat platform</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="documentation">
+                <xs:annotation>
+                    <xs:documentation>Documentation, guides, or how-to instructions</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="support">
+                <xs:annotation>
+                    <xs:documentation>Community or commercial support</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="source-distribution">
+                <xs:annotation>
+                    <xs:documentation>The location where the source code distributable can be obtained. This is often an archive format such as zip or tgz. The source-distribution type complements use of the version control (vcs) type.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="distribution">
+                <xs:annotation>
+                    <xs:documentation>Direct or repository download location</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="distribution-intake">
+                <xs:annotation>
+                    <xs:documentation>The location where a component was published to. This is often the same as "distribution" but may also include specialized publishing processes that act as an intermediary</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="license">
+                <xs:annotation>
+                    <xs:documentation>
+                        The URL to the license file. If a license URL has been defined in the license
+                        node, it should also be defined as an external reference for completeness.
+                        Example: https://www.apache.org/licenses/LICENSE-2.0.txt
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="build-meta">
+                <xs:annotation>
+                    <xs:documentation>Build-system specific meta file (i.e. pom.xml, package.json, .nuspec, etc)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="build-system">
+                <xs:annotation>
+                    <xs:documentation>URL to an automated build system</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="release-notes">
+                <xs:annotation>
+                    <xs:documentation>URL to release notes</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="security-contact">
+                <xs:annotation>
+                    <xs:documentation>Specifies a way to contact the maintainer, supplier, or provider in the event of a security incident. Common URIs include links to a disclosure procedure, a mailto (RFC-2368) that specifies an email address, a tel (RFC-3966) that specifies a phone number, or dns (RFC-4501) that specifies the records containing DNS Security TXT.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="model-card">
+                <xs:annotation>
+                    <xs:documentation>A model card describes the intended uses of a machine learning model, potential
+                        limitations, biases, ethical considerations, training parameters, datasets used to train the
+                        model, performance metrics, and other relevant data useful for ML transparency.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="log">
+                <xs:annotation>
+                    <xs:documentation>A record of events that occurred in a computer system or application, such as problems, errors, or information on current operations.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="configuration">
+                <xs:annotation>
+                    <xs:documentation>Parameters or settings that may be used by other components or services.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="evidence">
+                <xs:annotation>
+                    <xs:documentation>Information used to substantiate a claim.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="formulation">
+                <xs:annotation>
+                    <xs:documentation>Describes the formulation of any referencable object within the BOM, including components, services, metadata, declarations, or the BOM itself.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="attestation">
+                <xs:annotation>
+                    <xs:documentation>Human or machine-readable statements containing facts, evidence, or testimony</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="threat-model">
+                <xs:annotation>
+                    <xs:documentation>An enumeration of identified weaknesses, threats, and countermeasures, dataflow diagram (DFD), attack tree, and other supporting documentation in human-readable or machine-readable format</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="adversary-model">
+                <xs:annotation>
+                    <xs:documentation>The defined assumptions, goals, and capabilities of an adversary.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="risk-assessment">
+                <xs:annotation>
+                    <xs:documentation>Identifies and analyzes the potential of future events that may negatively impact individuals, assets, and/or the environment. Risk assessments may also include judgments on the tolerability of each risk.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="vulnerability-assertion">
+                <xs:annotation>
+                    <xs:documentation>A Vulnerability Disclosure Report (VDR) which asserts the known and previously unknown vulnerabilities that affect a component, service, or product including the analysis and findings describing the impact (or lack of impact) that the reported vulnerability has on a component, service, or product.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="exploitability-statement">
+                <xs:annotation>
+                    <xs:documentation>A Vulnerability Exploitability eXchange (VEX) which asserts the known vulnerabilities that do not affect a product, product family, or organization, and optionally the ones that do. The VEX should include the analysis and findings describing the impact (or lack of impact) that the reported vulnerability has on the product, product family, or organization.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="pentest-report">
+                <xs:annotation>
+                    <xs:documentation>Results from an authorized simulated cyberattack on a component or service, otherwise known as a penetration test</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="static-analysis-report">
+                <xs:annotation>
+                    <xs:documentation>SARIF or proprietary machine or human-readable report for which static analysis has identified code quality, security, and other potential issues with the source code</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dynamic-analysis-report">
+                <xs:annotation>
+                    <xs:documentation>Dynamic analysis report that has identified issues such as vulnerabilities and misconfigurations</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="runtime-analysis-report">
+                <xs:annotation>
+                    <xs:documentation>Report generated by analyzing the call stack of a running application</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="component-analysis-report">
+                <xs:annotation>
+                    <xs:documentation>Report generated by Software Composition Analysis (SCA), container analysis, or other forms of component analysis</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="maturity-report">
+                <xs:annotation>
+                    <xs:documentation>Report containing a formal assessment of an organization, business unit, or team against a maturity model</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="certification-report">
+                <xs:annotation>
+                    <xs:documentation>Industry, regulatory, or other certification from an accredited (if applicable) certification body</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="quality-metrics">
+                <xs:annotation>
+                    <xs:documentation>Report or system in which quality metrics can be obtained</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="codified-infrastructure">
+                <xs:annotation>
+                    <xs:documentation>Code or configuration that defines and provisions virtualized infrastructure, commonly referred to as Infrastructure as Code (IaC)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="poam">
+                <xs:annotation>
+                    <xs:documentation>Plans of Action and Milestones (POA&amp;M) complement an "attestation" external reference. POA&amp;M is defined by NIST as a "document that identifies tasks needing to be accomplished. It details resources required to accomplish the elements of the plan, any milestones in meeting the tasks and scheduled completion dates for the milestones".</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="electronic-signature">
+                <xs:annotation>
+                    <xs:documentation>An e-signature is commonly a scanned representation of a written signature or a stylized script of the persons name.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="digital-signature">
+                <xs:annotation>
+                    <xs:documentation>A signature that leverages cryptography, typically public/private key pairs, which provides strong authenticity verification.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="rfc-9116">
+                <xs:annotation>
+                    <xs:documentation>Document that complies with RFC-9116 (A File Format to Aid in Security Vulnerability Disclosure)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="patent">
+                <xs:annotation>
+                    <xs:documentation>References information about patents which may be defined in human-readable documents or in machine-readable formats such as CycloneDX or ST.96. For detailed patent information or to reference the information provided directly by patent offices, it is recommended to leverage standards from the World Intellectual Property Organization (WIPO) such as [ST.96](https://www.wipo.int/standards/en/st96).</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="patent-family">
+                <xs:annotation>
+                    <xs:documentation>References information about a patent family which may be defined in human-readable documents or in machine-readable formats such as CycloneDX or ST.96. A patent family is a group of related patent applications or granted patents that cover the same or similar invention. For detailed patent family information or to reference the information provided directly by patent offices, it is recommended to leverage standards from the World Intellectual Property Organization (WIPO) such as [ST.96](https://www.wipo.int/standards/en/st96).</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="patent-assertion">
+                <xs:annotation>
+                    <xs:documentation>References assertions made regarding patents associated with a component or service. Assertions distinguish between ownership, licensing, and other relevant interactions with patents.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="citation">
+                <xs:annotation>
+                    <xs:documentation>A reference to external citations applicable to the object identified by this BOM entry or the BOM itself. When used with a BOM-Link, this allows offloading citations into a separate CycloneDX BOM.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="other">
+                <xs:annotation>
+                    <xs:documentation>Use this if no other types accurately describe the purpose of the external reference</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="externalReferences">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                External references provide a way to document systems, sites, and information that may be
+                relevant, but are not included with the BOM. They may also establish specific relationships
+                within or external to the BOM.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="reference" type="bom:externalReference">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Zero or more external references can be defined</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="externalReference">
+        <xs:sequence>
+            <xs:element name="url" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The URI (URL or URN) to the external reference. External references
+                        are URIs and therefore can accept any URL scheme including https, mailto, tel, and dns.
+                        External references may also include formally registered URNs such as CycloneDX BOM-Link to
+                        reference CycloneDX BOMs or any object within a BOM. BOM-Link transforms applicable external
+                        references into relationships that can be expressed in a BOM or across BOMs. Refer to:
+                        https://cyclonedx.org/capabilities/bomlink/</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:union memberTypes="xs:anyURI bom:bomLinkType"/>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="comment" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">A comment describing the external reference</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="hashes" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="hash" type="bom:hashType"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="type" type="bom:externalReferenceType" use="required">
+            <xs:annotation>
+                <xs:documentation>Specifies the type of external reference. There are built-in types to describe common
+                    references. If a type does not exist for the reference being referred to, use the "other" type.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="commitsType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">Zero or more commits can be specified.</xs:documentation>
+        </xs:annotation>
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="commit" type="bom:commitType">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Specifies an individual commit.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="commitType">
+        <xs:sequence>
+            <xs:element name="uid" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">A unique identifier of the commit. This may be version control
+                        specific. For example, Subversion uses revision numbers whereas git uses commit hashes.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The URL to the commit. This URL will typically point to a commit
+                        in a version control system.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="author" type="bom:identifiableActionType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The author who created the changes in the commit</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="committer" type="bom:identifiableActionType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The person who committed or pushed the commit</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="message" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The text description of the contents of the commit</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="patchesType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">Zero or more patches can be specified.</xs:documentation>
+        </xs:annotation>
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="patch" type="bom:patchType">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Specifies an individual patch.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="patchType">
+        <xs:sequence>
+            <xs:element name="diff" type="bom:diffType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The patch file (or diff) that show changes.
+                        Refer to https://en.wikipedia.org/wiki/Diff</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="resolves" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="issue" type="bom:issueType"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="type" type="bom:patchClassification" use="required">
+            <xs:annotation>
+                <xs:documentation>Specifies the purpose for the patch including the resolution of defects,
+                    security issues, or new behavior or functionality</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="patchClassification">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="unofficial">
+                <xs:annotation>
+                    <xs:documentation>A patch which is not developed by the creators or maintainers of the software
+                        being patched. Refer to https://en.wikipedia.org/wiki/Unofficial_patch</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="monkey">
+                <xs:annotation>
+                    <xs:documentation>A patch which dynamically modifies runtime behavior.
+                        Refer to https://en.wikipedia.org/wiki/Monkey_patch</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="backport">
+                <xs:annotation>
+                    <xs:documentation>A patch which takes code from a newer version of software and applies
+                        it to older versions of the same software. Refer to https://en.wikipedia.org/wiki/Backporting</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="cherry-pick">
+                <xs:annotation>
+                    <xs:documentation>A patch created by selectively applying commits from other versions or
+                        branches of the same software.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="issueClassification">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="defect">
+                <xs:annotation>
+                    <xs:documentation>A fault, flaw, or bug in software</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="enhancement">
+                <xs:annotation>
+                    <xs:documentation>A new feature or behavior in software</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="security">
+                <xs:annotation>
+                    <xs:documentation>A special type of defect which impacts security</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="diffType">
+        <xs:sequence>
+            <xs:element name="text" type="bom:attachedTextType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Specifies the text of the diff</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Specifies the URL to the diff</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="issueType">
+        <xs:annotation>
+            <xs:documentation>
+                An individual issue that has been resolved.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="id" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The identifier of the issue assigned by the source of the issue</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The name of the issue</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">A description of the issue</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="source" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            The source of the issue where it is documented.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:sequence>
+                        <xs:element name="name" minOccurs="0" type="xs:normalizedString" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    The name of the source. For example "National Vulnerability Database",
+                                    "NVD", and "Apache"
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="url" minOccurs="0" type="xs:anyURI" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    The url of the issue documentation as provided by the source
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="references" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        A collection of URL's for reference. Multiple URLs are allowed.
+                        Example: "https://example.com"
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="url" type="xs:anyURI"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="type" type="bom:issueClassification" use="required">
+            <xs:annotation>
+                <xs:documentation>Specifies the type of issue</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="identifiableActionType">
+        <xs:sequence>
+            <xs:element name="timestamp" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The timestamp in which the action occurred</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The name of the individual who performed the action</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="email" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The email address of the individual who performed the action</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="pedigreeType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Component pedigree is a way to document complex supply chain scenarios where components are created,
+                distributed, modified, redistributed, combined with other components, etc. Pedigree supports viewing
+                this complex chain from the beginning, the end, or anywhere in the middle. It also provides a way to
+                document variants where the exact relation may not be known.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="ancestors" type="bom:componentsType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Describes zero or more components in which a component is derived
+                        from. This is commonly used to describe forks from existing projects where the forked version
+                        contains a ancestor node containing the original component it was forked from. For example,
+                        Component A is the original component. Component B is the component being used and documented
+                        in the BOM. However, Component B contains a pedigree node with a single ancestor documenting
+                        Component A - the original component from which Component B is derived from.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="descendants" type="bom:componentsType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Descendants are the exact opposite of ancestors. This provides a
+                        way to document all forks (and their forks) of an original or root component.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="variants" type="bom:componentsType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Variants describe relations where the relationship between the
+                        components are not known. For example, if Component A contains nearly identical code to
+                        Component B. They are both related, but it is unclear if one is derived from the other,
+                        or if they share a common ancestor.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="commits" type="bom:commitsType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">A list of zero or more commits which provide a trail describing
+                        how the component deviates from an ancestor, descendant, or variant.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="patches" type="bom:patchesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">A list of zero or more patches describing how the component
+                        deviates from an ancestor, descendant, or variant. Patches may be complementary to commits
+                        or may be used in place of commits.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="notes" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Notes, observations, and other non-structured commentary
+                        describing the components pedigree.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="dependencyType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="dependency" type="bom:dependencyType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>The component or service that is a dependency of this dependency object.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="provides" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The component or service that define a given specification or standard, which is provided or implemented by this dependency object.
+                        For example, a cryptographic library which implements a cryptographic algorithm. A component which implements another component does not imply that the implementation is in use.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:attribute name="ref" type="bom:refLinkType" use="required">
+                        <xs:annotation>
+                            <xs:documentation>References a component or service by its bom-ref attribute</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="ref" type="bom:refLinkType" use="required">
+            <xs:annotation>
+                <xs:documentation>References a component or service by its bom-ref attribute</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##other" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="dependenciesType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="dependency" type="bom:dependencyType">
+                <xs:annotation>
+                    <xs:documentation>Defines the direct dependencies of a component or service. Components or services
+                        that do not have their own dependencies must be declared as empty elements within the graph.
+                        Components or services that are not represented in the dependency graph may have unknown
+                        dependencies. It is recommended that implementations assume this to be opaque and not an
+                        indicator of a object being dependency-free. It is recommended to leverage compositions to
+                        indicate unknown dependency graphs.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="servicesType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="service" type="bom:service"/>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="service">
+        <xs:sequence>
+            <xs:element name="provider" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The organization that provides the service.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="group" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The grouping name, namespace, or identifier. This will often be a shortened,
+                        single name of the company or project that produced the service or domain name.
+                        Whitespace and special characters should be avoided.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" type="xs:normalizedString" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The name of the service. This will often be a shortened, single name
+                        of the service.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="version" type="bom:versionType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The service version.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Specifies a description for the service.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="endpoints" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The endpoint URIs of the service. Multiple endpoints are allowed.
+                        Example: "https://example.com/api/v1/ticker"
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="endpoint" type="xs:anyURI" minOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>A service endpoint URI.</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="authenticated" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A boolean value indicating if the service requires authentication.
+                        A value of true indicates the service requires authentication prior to use.
+                        A value of false indicates the service does not require authentication.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="x-trust-boundary" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A boolean value indicating if use of the service crosses a trust zone or boundary.
+                        A value of true indicates that by using the service, a trust boundary is crossed.
+                        A value of false indicates that by using the service, a trust boundary is not crossed.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="trustZone" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The name of the trust zone the service resides in.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="data" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Specifies information about the data including the directional flow of data and the data classification.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:choice>
+                        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                            <xs:element name="classification" type="bom:dataClassificationType">
+                                <xs:annotation>
+                                    <xs:documentation>DEPRECATED: Specifies the data classification. THIS FIELD IS DEPRECATED AS OF v1.5. Use `./dataflow/classification` instead</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:element name="dataflow" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>Specifies the data classification.</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="classification" type="bom:dataClassificationType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>Specifies the data classification.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="governance" type="bom:dataGovernance" minOccurs="0" maxOccurs="1" />
+                                    <xs:element name="source" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>The URI, URL, or BOM-Link of the components or services the data came in from.</xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                                                <xs:element name="url">
+                                                    <xs:simpleType>
+                                                        <xs:union memberTypes="xs:anyURI bom:bomLinkElementType"/>
+                                                    </xs:simpleType>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="destination" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>The URI, URL, or BOM-Link of the components or services the data is sent to.</xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                                                <xs:element name="url">
+                                                    <xs:simpleType>
+                                                        <xs:union memberTypes="xs:anyURI bom:bomLinkElementType"/>
+                                                    </xs:simpleType>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                                <xs:attribute name="name" type="xs:string" use="optional">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Name for the defined data.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="description" type="xs:string" use="optional">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Short description of the data content and usage.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:anyAttribute namespace="##any" processContents="lax">
+                                    <xs:annotation>
+                                        <xs:documentation>User-defined attributes may be used on this element as long as they
+                                            do not have the same name as an existing attribute used by the schema.</xs:documentation>
+                                    </xs:annotation>
+                                </xs:anyAttribute>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:choice>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="licenses" type="bom:licenseChoiceType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="patentAssertions" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A list of assertions made regarding patents associated with this component or service. Assertions distinguish between ownership, licensing, and other relevant interactions with patents.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="patentAssertion" type="bom:patentAssertionType"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="externalReferences" type="bom:externalReferences" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document external references related to the service.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="services" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A list of services included or deployed behind the parent service. This is not a dependency
+                        tree. It provides a way to specify a hierarchical representation of service assemblies.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="service" type="bom:service"/>
+                        <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:any>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="releaseNotes" type="bom:releaseNotesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Specifies release notes.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="tags" type="bom:tagsType" minOccurs="0" maxOccurs="1" />
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An identifier which can be used to reference the service elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="dataClassificationType">
+        <xs:annotation>
+            <xs:documentation>Specifies the data classification.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="xs:normalizedString">
+                <xs:attribute name="flow" type="bom:dataFlowType" use="required">
+                    <xs:annotation>
+                        <xs:documentation>Specifies the flow direction of the data.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:simpleType name="dataFlowType">
+        <xs:annotation>
+            <xs:documentation>Specifies the flow direction of the data. Valid values are:
+                inbound, outbound, bi-directional, and unknown. Direction is relative to the service.
+                Inbound flow states that data enters the service. Outbound flow states that data
+                leaves the service. Bi-directional states that data flows both ways, and unknown
+                states that the direction is not known.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="inbound">
+                <xs:annotation>
+                    <xs:documentation>
+                        Data that enters a service.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="outbound">
+                <xs:annotation>
+                    <xs:documentation>Data that exits a service.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="bi-directional">
+                <xs:annotation>
+                    <xs:documentation>Data flows in and out of the service.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="unknown">
+                <xs:annotation>
+                    <xs:documentation>The directional flow of data is not known.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="licenseChoiceType">
+        <xs:annotation>
+            <xs:documentation>A list of SPDX licenses and/or named licenses and/or SPDX License Expression.</xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="license" type="bom:licenseType"/>
+            <xs:element name="expression" type="bom:licenseExpressionType"/>
+            <xs:element name="expression-detailed" type="bom:licenseExpressionDetailedType"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:simpleType name="licenseAcknowledgementEnumerationType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="declared">
+                <xs:annotation>
+                    <xs:documentation>
+                        Declared licenses represent the initial intentions of authors regarding
+                        the licensing terms of their code.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="concluded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Concluded licenses are verified and confirmed.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="copyrightsType">
+        <xs:sequence>
+            <xs:element name="text" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="identityFieldType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="group"/>
+            <xs:enumeration value="name"/>
+            <xs:enumeration value="version"/>
+            <xs:enumeration value="purl"/>
+            <xs:enumeration value="cpe"/>
+            <xs:enumeration value="omniborId"/>
+            <xs:enumeration value="swhid"/>
+            <xs:enumeration value="swid"/>
+            <xs:enumeration value="hash"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="decimalPercentType">
+        <xs:restriction base="xs:decimal">
+            <xs:minInclusive value="0"/>
+            <xs:maxInclusive value="1"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="evidenceTechnique">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="source-code-analysis">
+                <xs:annotation>
+                    <xs:documentation>
+                        Examines the source code without executing it.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="binary-analysis">
+                <xs:annotation>
+                    <xs:documentation>
+                        Examines a compiled binary through reverse engineering, typically via disassembly or bytecode reversal.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="manifest-analysis">
+                <xs:annotation>
+                    <xs:documentation>
+                        Examines a package management system such as those used for building software or installing software.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ast-fingerprint">
+                <xs:annotation>
+                    <xs:documentation>
+                        Examines the Abstract Syntax Tree (AST) of source code or a compiled binary.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="hash-comparison">
+                <xs:annotation>
+                    <xs:documentation>
+                        Evaluates the cryptographic hash of a component against a set of pre-computed hashes of identified software.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="instrumentation">
+                <xs:annotation>
+                    <xs:documentation>
+                        Examines the call stack of running applications by intercepting and monitoring application logic without the need to modify the application.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dynamic-analysis">
+                <xs:annotation>
+                    <xs:documentation>
+                        Evaluates a running application.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="filename">
+                <xs:annotation>
+                    <xs:documentation>
+                        Evaluates file name of a component against a set of known file names of identified software.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="attestation">
+                <xs:annotation>
+                    <xs:documentation>
+                        A testimony to the accuracy of the identify of a component made by an individual or entity.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="other">
+                <xs:annotation>
+                    <xs:documentation>
+                        Any other technique.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="componentEvidenceType">
+        <xs:sequence>
+            <xs:element name="identity" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>Evidence that substantiates the identity of a component. The identify may be an
+                        object or an array of identity objects. Support for specifying identity as a single object was
+                        introduced in CycloneDX v1.5. "unbounded" was introduced in v1.6. It is recommended that all
+                        implementations are aware of "unbounded".</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="field" type="bom:identityFieldType" minOccurs="1" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>The identity field of the component which the evidence describes.</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="confidence" type="bom:decimalPercentType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>The overall confidence of the evidence from 0 - 1, where 1 is 100% confidence.</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="concludedValue" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>The value of the field (cpe, purl, etc) that has been concluded based on the aggregate of all methods (if available).</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="methods" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>The methods used to extract and/or analyze the evidence.</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="method" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="technique" type="bom:evidenceTechnique" minOccurs="1" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>The technique used in this method of analysis.</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="confidence" type="bom:decimalPercentType" minOccurs="1" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>The confidence of the evidence from 0 - 1, where 1 is 100% confidence. Confidence is specific to the technique used. Each technique of analysis can have independent confidence.</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>The value or contents of the evidence.</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="tools" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The object in the BOM identified by its bom-ref. This is often a component or service,
+                                    but may be any object type supporting bom-refs. Tools used for analysis should already
+                                    be defined in the BOM, either in the metadata/tools, components, or formulation.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="tool" type="bom:bomReferenceType" minOccurs="0" maxOccurs="unbounded"/>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="occurrences" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Evidence of individual instances of a component spread across multiple locations.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="occurrence" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="location" type="xs:string" minOccurs="1" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>The location or path to where the component was found.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="line" type="xs:nonNegativeInteger" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>The line number where the component was found.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="offset" type="xs:nonNegativeInteger" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>The offset where the component was found.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="symbol" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>The symbol name that was found associated with the component.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="additionalContext" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>Any additional context of the detected component (e.g. a code snippet).</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+
+                                </xs:sequence>
+                                <xs:attribute name="bom-ref" type="bom:refType">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            An identifier which can be used to reference the occurrence elsewhere
+                                            in the BOM. Every `bom-ref` must be unique within the BOM.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="callstack" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Evidence of the components use through the callstack.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="frames" minOccurs="0" maxOccurs="1">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="frame" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Within a call stack, a frame is a discrete unit that encapsulates an execution context, including local variables, parameters, and the return address. As function calls are made, frames are pushed onto the stack, forming an array-like structure that orchestrates the flow of program execution and manages the sequence of function invocations.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="package" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>A package organizes modules into namespaces, providing a unique namespace for each type it contains.</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="module" type="xs:string" minOccurs="1" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>A module or class that encloses functions/methods and other code.</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="function" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>A block of code designed to perform a particular task.</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="parameters" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Arguments that are passed to the module or function.</xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="parameter" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="line" type="xs:integer" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>The line number the code that is called resides on.</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="column" type="xs:integer" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>The column the code that is called resides.</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="fullFilename" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>The full path and filename of the module.</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="tools" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The object in the BOM identified by its bom-ref. This is often a component or service,
+                                    but may be any object type supporting bom-refs. Tools used for analysis should already
+                                    be defined in the BOM, either in the metadata/tools, components, or formulation.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="tool" type="bom:bomReferenceType" minOccurs="0" maxOccurs="unbounded"/>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="licenses" type="bom:licenseChoiceType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="copyright" type="bom:copyrightsType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Copyright evidence captures intellectual property assertions, providing evidence of possible ownership and legal protection.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="compositionsType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="composition" type="bom:compositionType"/>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="compositionType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="aggregate" type="bom:aggregateType" default="not_specified">
+                <xs:annotation>
+                    <xs:documentation>Specifies an aggregate type that describes how complete a relationship is.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="assemblies" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The bom-ref identifiers of the components or services being described. Assemblies refer to
+                        nested relationships whereby a constituent part may include other constituent parts. References
+                        do not cascade to child parts. References are explicit for the specified constituent part only.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="assembly" type="bom:bomReferenceType"/>
+                        <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:any>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="dependencies" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The bom-ref identifiers of the components or services being described. Dependencies refer to a
+                        relationship whereby an independent constituent part requires another independent constituent
+                        part. References do not cascade to transitive dependencies. References are explicit for the
+                        specified dependency only.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="dependency" type="bom:bomReferenceType"/>
+                        <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:any>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="vulnerabilities" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The bom-ref identifiers of the vulnerabilities being described.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="vulnerability" type="bom:bomReferenceType"/>
+                        <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:any>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An identifier which can be used to reference the composition elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="aggregateType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="complete">
+                <xs:annotation>
+                    <xs:documentation>The relationship is complete. No further relationships including constituent components, services, or dependencies are known to exist.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="incomplete">
+                <xs:annotation>
+                    <xs:documentation>The relationship is incomplete. Additional relationships exist and may include constituent components, services, or dependencies.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="incomplete_first_party_only">
+                <xs:annotation>
+                    <xs:documentation>The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="incomplete_first_party_proprietary_only">
+                <xs:annotation>
+                    <xs:documentation>The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented, limited specifically to those that are proprietary.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="incomplete_first_party_opensource_only">
+                <xs:annotation>
+                    <xs:documentation>The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented, limited specifically to those that are opensource.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="incomplete_third_party_only">
+                <xs:annotation>
+                    <xs:documentation>The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="incomplete_third_party_proprietary_only">
+                <xs:annotation>
+                    <xs:documentation>The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented, limited specifically to those that are proprietary.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="incomplete_third_party_opensource_only">
+                <xs:annotation>
+                    <xs:documentation>The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented, limited specifically to those that are opensource.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="unknown">
+                <xs:annotation>
+                    <xs:documentation>The relationship may be complete or incomplete. This usually signifies a 'best-effort' to obtain constituent components, services, or dependencies but the completeness is inconclusive.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="not_specified">
+                <xs:annotation>
+                    <xs:documentation>The relationship completeness is not specified.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="localeType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Defines a syntax for representing two character language code (ISO-639) followed by an optional two
+                character country code. The language code must be lower case. If the country code is specified, the
+                country code must be upper case. The language code and country code must be separated by a minus sign.
+                Examples: en, en-US, fr, fr-CA
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="([a-z]{2})(-[A-Z]{2})?"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="releaseNotesType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="type" type="xs:normalizedString" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The software versioning type. It is recommended that the release type use one
+                        of 'major', 'minor', 'patch', 'pre-release', or 'internal'. Representing all possible software
+                        release types is not practical, so standardizing on the recommended values, whenever possible,
+                        is strongly encouraged.
+                        * major = A major release may contain significant changes or may introduce breaking changes.
+                        * minor = A minor release, also known as an update, may contain a smaller number of changes than major releases.
+                        * patch = Patch releases are typically unplanned and may resolve defects or important security issues.
+                        * pre-release = A pre-release may include alpha, beta, or release candidates and typically have
+                          limited support. They provide the ability to preview a release prior to its general availability.
+                        * internal = Internal releases are not for public consumption and are intended to be used exclusively
+                          by the project or manufacturer that produced it.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="title" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The title of the release.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="featuredImage" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The URL to an image that may be prominently displayed with the release note.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="socialImage" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The URL to an image that may be used in messaging on social media platforms.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A short description of the release.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="timestamp" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The date and time (timestamp) when the release note was created.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="aliases" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="alias" type="xs:normalizedString">
+                            <xs:annotation>
+                                <xs:documentation>One or more alternate names the release may be referred to. This may
+                                    include unofficial terms used by development and marketing teams (e.g. code names).
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="tags" type="bom:tagsType" minOccurs="0" maxOccurs="1" />
+            <xs:element name="resolves" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A collection of issues that have been resolved.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="issue" type="bom:issueType"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="notes" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="note">
+                            <xs:annotation>
+                                <xs:documentation>Zero or more release notes containing the locale and content. Multiple
+                                    note elements may be specified to support release notes in a wide variety of languages.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                                    <xs:element name="locale" type="bom:localeType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>The ISO-639 (or higher) language code and optional ISO-3166
+                                                (or higher) country code. Examples include: "en", "en-US", "fr" and "fr-CA".</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="text" type="bom:attachedTextType" minOccurs="1" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>Specifies the full content of the release note.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="modelCardType">
+        <!--
+        Model card support in CycloneDX is derived from TensorFlow Model Card Toolkit released under the Apache 2.0 license and
+        available from https://github.com/tensorflow/model-card-toolkit/blob/main/model_card_toolkit/schema/v0.0.2/model_card.schema.json.
+        In addition, CycloneDX model card support includes portions of VerifyML, also released under the Apache 2.0 license and
+        available from https://github.com/cylynx/verifyml/blob/main/verifyml/model_card_toolkit/schema/v0.0.4/model_card.schema.json.
+        -->
+        <xs:annotation>
+            <xs:documentation>
+                A model card describes the intended uses of a machine learning model and potential limitations, including
+                biases and ethical considerations. Model cards typically contain the training parameters, which datasets
+                were used to train the model, performance metrics, and other relevant data useful for ML transparency.
+                This object SHOULD be specified for any component of type `machine-learning-model` and must not be specified
+                for other component types.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="modelParameters" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Hyper-parameters for construction of the model.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="approach" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The overall approach to learning used by the model for problem solving.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="type" type="bom:machineLearningApproachType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Learning types describing the learning problem or hybrid learning problem.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="task" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Directly influences the input and/or output. Examples include classification,
+                                    regression, clustering, etc.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="architectureFamily" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The model architecture family such as transformer network, convolutional neural
+                                    network, residual neural network, LSTM neural network, etc.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="modelArchitecture" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The specific architecture of the model such as GPT-1, ResNet-50, YOLOv3, etc.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="datasets" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The datasets used to train and evaluate the model.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                    <xs:element name="ref" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>References a data component by the components bom-ref attribute</xs:documentation>
+                                        </xs:annotation>
+                                        <xs:simpleType>
+                                            <xs:union memberTypes="bom:refLinkType bom:bomLinkElementType"/>
+                                        </xs:simpleType>
+                                    </xs:element>
+                                    <xs:element name="dataset" type="bom:componentDataType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>Inline Data Information</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:choice>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="inputs" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The input format(s) of the model
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="input" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="format" type="xs:string" minOccurs="1" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The data format for input to the model. Example formats include string, image, time-series
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="outputs" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The output format(s) from the model
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="output" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="format" type="xs:string" minOccurs="1" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The data format for output from the model. Example formats include string, image, time-series
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="quantitativeAnalysis" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A quantitative analysis of the model
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="performanceMetrics" minOccurs="0" maxOccurs="1">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="performanceMetric" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The type of performance metric.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The value of the performance metric.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="slice" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The name of the slice this metric was computed on. By default, assume
+                                                            this metric is not sliced.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="confidenceInterval" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The confidence interval of the metric.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="lowerBound" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The lower bound of the confidence interval.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                            <xs:element name="upperBound" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The upper bound of the confidence interval.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="graphics" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    A collection of graphics that represent various measurements
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                A description of this collection of graphics.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="collection" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                A collection of graphics.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="graphic" minOccurs="0" maxOccurs="unbounded">
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The name of the graphic.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                            <xs:element name="image" type="bom:attachedTextType" minOccurs="0" maxOccurs="1">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The graphic (vector or raster). Base64 encoding must be specified for binary images.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="considerations" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        What considerations should be taken into account regarding the model's construction, training,
+                        and application?
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="users" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Who are the intended users of the model?
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="user" type="xs:string" minOccurs="0" maxOccurs="1" />
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="useCases" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    What are the intended use cases of the model?
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="useCase" type="xs:string" minOccurs="0" maxOccurs="1" />
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="technicalLimitations" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    What are the known technical limitations of the model? E.g. What kind(s) of data
+                                    should the model be expected not to perform well on? What are the factors that might
+                                    degrade model performance?
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="technicalLimitation" type="xs:string" minOccurs="0" maxOccurs="1" />
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="performanceTradeoffs" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    What are the known tradeoffs in accuracy/performance of the model?
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="performanceTradeoff" type="xs:string" minOccurs="0" maxOccurs="1" />
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="ethicalConsiderations" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    What are the ethical risks involved in the application of this model?
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="ethicalConsideration" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The name of the risk
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="mitigationStrategy" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            Strategy used to address this risk
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="environmentalConsiderations" type="bom:environmentalConsiderationsType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    What are the various environmental impacts the corresponding machine learning model has exhibited across its lifecycle?
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="fairnessAssessments" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    How does the model affect groups at risk of being systematically disadvantaged?
+                                    What are the harms and benefits to the various affected groups?
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="fairnessAssessment" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="groupAtRisk" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The groups or individuals at risk of being systematically disadvantaged by the model.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="benefits" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            Expected benefits to the identified groups.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="harms" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            Expected harms to the identified groups.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="mitigationStrategy" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            With respect to the benefits and harms outlined, please
+                                                            describe any mitigation strategy implemented.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An identifier which can be used to reference the model card elsewhere in the BOM.
+                    Every `bom-ref` must be unique within the BOM.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="environmentalConsiderationsType">
+        <xs:annotation>
+            <xs:documentation>
+                Describes various environmental impact metrics.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="energyConsumptions" type="bom:energyConsumptionsType" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Describes energy consumption information incurred for one or more component lifecycle activities.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="energyConsumptionsType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="energyConsumption" type="bom:energyConsumptionType"/>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="energyConsumptionType">
+        <xs:annotation>
+            <xs:documentation>
+                Describes energy consumption information incurred for the specified lifecycle activity.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="activity" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The type of activity that is part of a machine learning model development or operational lifecycle.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="design">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    model design including problem framing, goal definition and algorithm selection.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="data-collection">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    model data acquisition including search, selection and transfer.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="data-preparation">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    model data preparation including data cleaning, labeling and conversion.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="training">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    model building, training and generalized tuning.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="fine-tuning">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    refining a trained model to produce desired outputs for a given problem space.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="validation">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    model validation including model output evaluation and testing.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="deployment">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    explicit model deployment to a target hosting infrastructure.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="inference">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    generating an output response from a hosted model from a set of inputs.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="other">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    a lifecycle activity type whose description does not match currently defined values.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="energyProviders" type="bom:energyProviderType" minOccurs="1" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        The provider(s) of the energy consumed by the associated model development lifecycle activity.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="activityEnergyCost" type="bom:energyMeasureType" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The total energy cost associated with the model lifecycle activity.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="co2CostEquivalent" type="bom:co2MeasureType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The CO2 cost (debit) equivalent to the total energy cost.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="co2CostOffset" type="bom:co2MeasureType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The CO2 offset (credit) for the CO2 equivalent cost.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="energyMeasureType">
+        <xs:annotation>
+            <xs:documentation>
+                A measure of energy.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="value" type="xs:decimal" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Quantity of energy.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="unit" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Unit of energy.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="kWh">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    kilowatt-hour (kWh) is the energy delivered by one kilowatt (kW) of power for one hour (h).
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="co2MeasureType">
+        <xs:annotation>
+            <xs:documentation>
+                A measure of carbon dioxide (CO2).
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="value" type="xs:decimal" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Quantity of carbon dioxide (CO2).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="unit" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Unit of carbon dioxide (CO2).
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="tCO2eq">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Tonnes (t) of carbon dioxide (CO2) equivalent (eq).
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="energyProviderType">
+        <xs:annotation>
+            <xs:documentation>
+                Describes the physical provider of energy used for model development or operations.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A description of the energy provider.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="organization" type="bom:organizationalEntity" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The organization of the energy provider.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="energySource" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The energy source for the energy provider.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="coal">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Energy produced by types of coal.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="oil">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Petroleum products (primarily crude oil and its derivative fuel oils).
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="natural-gas">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Hydrocarbon gas liquids (HGL) that occur as gases at atmospheric pressure and as liquids under higher pressures including Natural gas (C5H12 and heavier), Ethane (C2H6), Propane (C3H8), etc.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="nuclear">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Energy produced from the cores of atoms (i.e., through nuclear fission or fusion).
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="wind">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Energy produced from moving air.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="solar">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Energy produced from the sun (i.e., solar radiation).
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="geothermal">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Energy produced from heat within the earth.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="hydropower">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Energy produced from flowing water.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="biofuel">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Liquid fuels produced from biomass feedstocks (i.e., organic materials such as plants or animals).
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="unknown">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The energy source is unknown.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="other">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    An energy source that is not listed.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="energyProvided" type="bom:energyMeasureType" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The energy provided by the energy source for an associated activity.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="externalReferences" type="bom:externalReferences" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An identifier which can be used to reference the energy provider elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="postalAddressType">
+        <xs:annotation>
+            <xs:documentation>
+                An address used to identify a contactable location.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="country" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The country name or the two-letter ISO 3166-1 country code.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="region" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The region or state in the country. For example, Texas.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="locality" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The locality or city within the country. For example, Austin.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="postOfficeBoxNumber" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The post office box number. For example, 901.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="postalCode" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The postal code. For example, 78758.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="streetAddress" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The street address. For example, 100 Main Street.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An identifier which can be used to reference the address elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="machineLearningApproachType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="supervised">
+                <xs:annotation>
+                    <xs:documentation>
+                        Supervised machine learning involves training an algorithm on labeled
+                        data to predict or classify new data based on the patterns learned from
+                        the labeled examples.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="unsupervised">
+                <xs:annotation>
+                    <xs:documentation>
+                        Unsupervised machine learning involves training algorithms on unlabeled
+                        data to discover patterns, structures, or relationships without explicit
+                        guidance, allowing the model to identify inherent structures or clusters
+                        within the data.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="reinforcement-learning">
+                <xs:annotation>
+                    <xs:documentation>
+                        Reinforcement learning is a type of machine learning where an agent learns
+                        to make decisions by interacting with an environment to maximize cumulative
+                        rewards, through trial and error.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="semi-supervised">
+                <xs:annotation>
+                    <xs:documentation>
+                        Semi-supervised machine learning utilizes a combination of labeled and
+                        unlabeled data during training to improve model performance, leveraging
+                        the benefits of both supervised and unsupervised learning techniques.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="self-supervised">
+                <xs:annotation>
+                    <xs:documentation>
+                        Self-supervised machine learning involves training models to predict parts
+                        of the input data from other parts of the same data, without requiring
+                        external labels, enabling learning from large amounts of unlabeled data.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="componentDataType">
+        <xs:sequence>
+            <xs:element name="type" type="bom:componentDataTypeEnumeration" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The general theme or subject matter of the data being specified.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the dataset.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="contents" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The contents or references to the contents of the data being described.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="attachment" type="bom:attachedTextType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>A way to include textual or encoded data.</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>The URL to where the data can be retrieved.</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>Provides the ability to document name-value parameters used for configuration.</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="classification" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Data classification tags data according to its type, sensitivity, and value if altered, stolen, or destroyed.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="sensitiveData" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        A description of any sensitive data in a dataset.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="graphics" type="bom:graphicsCollectionType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A collection of graphics that represent various measurements.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A description of the dataset. Can describe size of dataset, whether it's used for source code,
+                        training, testing, or validation, etc.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="governance" type="bom:dataGovernance" minOccurs="0" maxOccurs="1" />
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An identifier which can be used to reference the dataset elsewhere in the BOM.
+                    Every `bom-ref` must be unique within the BOM.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="dataGovernance">
+        <xs:sequence>
+            <xs:element name="custodians" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Data custodians are responsible for the safe custody, transport, and storage of data.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="custodian" type="bom:organizationOrIndividualType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="stewards" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Data stewards are responsible for data content, context, and associated business rules.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="steward" type="bom:organizationOrIndividualType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="owners" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Data owners are concerned with risk and appropriate access to data.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="owner" type="bom:organizationOrIndividualType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="organizationOrIndividualType">
+        <xs:choice>
+            <xs:element name="organization" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1" />
+            <xs:element name="individual" type="bom:organizationalContact" minOccurs="0" maxOccurs="1" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="graphicsCollectionType">
+        <xs:annotation>
+            <xs:documentation>
+                A collection of graphics that represent various measurements.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A description of this collection of graphics.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="collection" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A collection of graphics.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="graphic" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The name of the graphic.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="image" type="bom:attachedTextType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The graphic (vector or raster). Base64 encoding must be specified for binary images.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="componentDataTypeEnumeration">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="source-code">
+                <xs:annotation>
+                    <xs:documentation>Any type of code, code snippet, or data-as-code.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="configuration">
+                <xs:annotation>
+                    <xs:documentation>Parameters or settings that may be used by other components.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset">
+                <xs:annotation>
+                    <xs:documentation>A collection of data.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="definition">
+                <xs:annotation>
+                    <xs:documentation>Data that can be used to create new instances of what the definition defines.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="other">
+                <xs:annotation>
+                    <xs:documentation>Any other type of data that does not fit into existing definitions.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="bomReferenceType">
+        <xs:attribute name="ref" use="required">
+            <xs:annotation>
+                <xs:documentation>References a component or service by its bom-ref attribute</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:union memberTypes="bom:refLinkType bom:bomLinkType"/>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##other" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="propertiesType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="property" type="bom:propertyType"/>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="propertyType">
+        <xs:annotation>
+            <xs:documentation>Specifies an individual property with a name and value.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="xs:normalizedString">
+                <xs:attribute name="name" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>The name of the property. Duplicate names are allowed, each potentially having a different value.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="vulnerabilitiesType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="vulnerability" type="bom:vulnerabilityType">
+                <xs:annotation>
+                    <xs:documentation>Defines a weakness in a component or service that could be exploited or triggered by a threat source.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="vulnerabilityType">
+        <xs:sequence minOccurs="0" maxOccurs="1">
+            <xs:element name="id" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The identifier that uniquely identifies the vulnerability. For example:
+                        CVE-2021-39182, GHSA-35m5-8cvj-8783, and SNYK-PYTHON-ENROCRYPT-1912876.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="source" type="bom:vulnerabilitySourceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The source that published the vulnerability.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="references" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Zero or more pointers to vulnerabilities that are the equivalent of the
+                        vulnerability specified. Often times, the same vulnerability may exist in multiple sources of
+                        vulnerability intelligence, but have different identifiers. References provide a way to
+                        correlate vulnerabilities across multiple sources of vulnerability intelligence.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="reference">
+                            <xs:annotation>
+                                <xs:documentation>A pointer to a vulnerability that is the equivalent of the
+                                    vulnerability specified.</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence minOccurs="1" maxOccurs="1">
+                                    <xs:element name="id" type="xs:normalizedString" minOccurs="1" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>The identifier that uniquely identifies the vulnerability. For example:
+                                                CVE-2021-39182, GHSA-35m5-8cvj-8783, and SNYK-PYTHON-ENROCRYPT-1912876.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="source" type="bom:vulnerabilitySourceType" minOccurs="1" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>The source that published the vulnerability.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:any>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="ratings" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">List of vulnerability ratings.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="rating" type="bom:ratingType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="cwes" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            List of Common Weaknesses Enumerations (CWEs) codes that describes this vulnerability.
+                            For example 399 (of https://cwe.mitre.org/data/definitions/399.html)
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:sequence>
+                        <xs:element name="cwe" type="xs:integer" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A description of the vulnerability as provided by the source.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="detail" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>If available, an in-depth description of the vulnerability as provided by the
+                        source organization. Details often include information useful in understanding root cause.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="recommendation" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Recommendations of how the vulnerability can be remediated or mitigated.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="workaround" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A bypass, usually temporary, of the vulnerability that reduces its likelihood and/or impact. Workarounds often involve changes to configuration or deployments.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="proofOfConcept" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            Evidence used to reproduce the vulnerability.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:sequence>
+                        <xs:element name="reproductionSteps" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>Precise steps to reproduce the vulnerability.</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="environment" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>A description of the environment in which reproduction was possible.</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="supportingMaterial" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>Supporting material that helps in reproducing or understanding how reproduction is possible. This may include screenshots, payloads, and PoC exploit code.</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="attachment" type="bom:attachedTextType" minOccurs="0" maxOccurs="unbounded" />
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="advisories" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            Published advisories of the vulnerability if provided.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:sequence>
+                        <xs:element name="advisory" type="bom:advisoryType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="created" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The date and time (timestamp) when the vulnerability record was created in the vulnerability database.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="published" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The date and time (timestamp) when the vulnerability record was first published.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="updated" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The date and time (timestamp) when the vulnerability record was last updated.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="rejected" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The date and time (timestamp) when the vulnerability record was rejected (if applicable).</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="credits" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Individuals or organizations credited with the discovery of the vulnerability.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="organizations" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>The organizations credited with vulnerability discovery.</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                                    <xs:element name="organization" type="bom:organizationalEntity"/>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="individuals" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>The individuals, not associated with organizations, that are credited with vulnerability discovery.</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                                    <xs:element name="individual" type="bom:organizationalContact"/>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="tools" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The tool(s) used to identify, confirm, or score the vulnerability.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:choice>
+                        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                            <xs:element name="tool" minOccurs="0" type="bom:toolType">
+                                <xs:annotation>
+                                    <xs:documentation>DEPRECATED. Use `../components` or `../services` instead.</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:sequence minOccurs="0" maxOccurs="1">
+                            <xs:element name="components" type="bom:componentsType" minOccurs="0" maxOccurs="1">
+                                <xs:annotation>
+                                    <xs:documentation>A list of software and hardware components used as tools.</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:element name="services" type="bom:servicesType" minOccurs="0" maxOccurs="1">
+                                <xs:annotation>
+                                    <xs:documentation>A list of services used as tools.</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="analysis" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            An assessment of the impact and exploitability of the vulnerability.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:sequence minOccurs="0" maxOccurs="1">
+                        <xs:element name="state" type="bom:impactAnalysisStateType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    Declares the current state of an occurrence of a vulnerability, after automated or manual analysis.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="justification" type="bom:impactAnalysisJustificationType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    The rationale of why the impact analysis state was asserted.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="responses" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>A response to the vulnerability by the manufacturer, supplier, or
+                                    project responsible for the affected component or service. More than one response
+                                    is allowed. Responses are strongly encouraged for vulnerabilities where the analysis
+                                    state is exploitable.</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                                    <xs:element name="response" type="bom:impactAnalysisResponsesType"/>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="detail" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    Detailed description of the impact including methods used during assessment.
+                                    If a vulnerability is not exploitable, this field should include specific details
+                                    on why the component or service is not impacted by this vulnerability.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="firstIssued" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    The date and time (timestamp) when the analysis was first issued.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="lastUpdated" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    The date and time (timestamp) when the analysis was last updated.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="affects" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The components or services that are affected by the vulnerability.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="target">
+                            <xs:complexType>
+                                <xs:sequence minOccurs="0" maxOccurs="1">
+                                    <xs:element name="ref" minOccurs="1" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>References a component or service by the objects bom-ref.</xs:documentation>
+                                        </xs:annotation>
+                                        <xs:simpleType>
+                                            <xs:union memberTypes="bom:refLinkType bom:bomLinkElementType"/>
+                                        </xs:simpleType>
+                                    </xs:element>
+                                    <xs:element name="versions" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>Zero or more individual versions or range of versions.</xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                                                <xs:element name="version">
+                                                    <xs:complexType>
+                                                        <xs:sequence minOccurs="0" maxOccurs="1">
+                                                            <xs:choice>
+                                                                <xs:element name="version" type="bom:versionType" minOccurs="1" maxOccurs="1">
+                                                                    <xs:annotation>
+                                                                        <xs:documentation>A single version of a component or service.</xs:documentation>
+                                                                    </xs:annotation>
+                                                                </xs:element>
+                                                                <xs:element name="range" type="bom:versionRangeType" minOccurs="1" maxOccurs="1">
+                                                                    <xs:annotation>
+                                                                        <xs:documentation>A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/vers-spec</xs:documentation>
+                                                                    </xs:annotation>
+                                                                </xs:element>
+                                                            </xs:choice>
+                                                            <xs:element name="status" type="bom:impactAnalysisAffectedStatusType" minOccurs="0" maxOccurs="1" default="affected">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The vulnerability status for the version or range of versions.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An identifier which can be used to reference the vulnerability elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="vulnerabilitySourceType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="name" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The name of the source.
+                        For example: NVD, National Vulnerability Database, OSS Index, VulnDB, and GitHub Advisories
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The url of the vulnerability documentation as provided by the source.
+                        For example: https://nvd.nist.gov/vuln/detail/CVE-2021-39182
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="ratingType">
+        <xs:sequence>
+            <xs:element name="source" type="bom:vulnerabilitySourceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The source that calculated the severity or risk rating of the vulnerability.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="score" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The numerical score of the rating.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="severity" type="bom:severityType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Textual representation of the severity that corresponds to the numerical score of the rating.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="method" type="bom:scoreSourceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The risk scoring methodology/standard used.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="vector" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Textual representation of the metric values used to score the vulnerability.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="justification" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A reason for rating the vulnerability as it was.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="advisoryType">
+        <xs:sequence>
+            <xs:element name="title" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A name of the advisory.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" type="xs:anyURI" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Location where the advisory can be obtained.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="annotationsType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="annotation" type="bom:annotationType"/>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="annotatorChoiceType">
+        <xs:choice>
+            <xs:element name="organization" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The organization that created the annotation</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="individual" type="bom:organizationalContact" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The person that created the annotation</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="component" type="bom:component" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The tool or component that created the annotation</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="service" type="bom:service" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The service that created the annotation</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="annotationType">
+        <xs:sequence>
+            <xs:element name="subjects" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The objects in the BOM identified by their bom-ref's. This is often components or services, but may be any object type supporting bom-refs.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="subject" type="bom:bomReferenceType"/>
+                        <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:any>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="annotator" type="bom:annotatorChoiceType" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The organization, individual, component, or service which created the textual content
+                        of the annotation.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="timestamp" type="xs:dateTime" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The date and time (timestamp) when the annotation was created.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="text" type="xs:string" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The textual content of the annotation.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An identifier which can be used to reference the annotation elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:simpleType name="severityType" final="restriction">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Textual representation of the severity of the vulnerability adopted by the analysis method. If the
+                analysis method uses values other than what is provided, the user is expected to translate appropriately.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="critical">
+                <xs:annotation>
+                    <xs:documentation>Critical severity</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="high">
+                <xs:annotation>
+                    <xs:documentation>High severity</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="medium">
+                <xs:annotation>
+                    <xs:documentation>Medium severity</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="low">
+                <xs:annotation>
+                    <xs:documentation>Low severity</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="info">
+                <xs:annotation>
+                    <xs:documentation>Informational warning.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="none">
+                <xs:annotation>
+                    <xs:documentation>None</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="unknown">
+                <xs:annotation>
+                    <xs:documentation>The severity is not known</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="impactAnalysisStateType" final="restriction">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Declares the current state of an occurrence of a vulnerability, after automated or manual analysis.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="resolved">
+                <xs:annotation>
+                    <xs:documentation>
+                        The vulnerability has been remediated.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="resolved_with_pedigree">
+                <xs:annotation>
+                    <xs:documentation>
+                        The vulnerability has been remediated and evidence of the changes are provided in the affected
+                        components pedigree containing verifiable commit history and/or diff(s).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="exploitable">
+                <xs:annotation>
+                    <xs:documentation>
+                        The vulnerability may be directly or indirectly exploitable.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="in_triage">
+                <xs:annotation>
+                    <xs:documentation>
+                        The vulnerability is being investigated.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="false_positive">
+                <xs:annotation>
+                    <xs:documentation>
+                        The vulnerability is not specific to the component or service and was falsely identified or associated.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="not_affected">
+                <xs:annotation>
+                    <xs:documentation>
+                        The component or service is not affected by the vulnerability. Justification should be specified
+                        for all not_affected cases.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="impactAnalysisJustificationType" final="restriction">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                The rationale of why the impact analysis state was asserted.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="code_not_present">
+                <xs:annotation>
+                    <xs:documentation>
+                        The code has been removed or tree-shaked.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="code_not_reachable">
+                <xs:annotation>
+                    <xs:documentation>
+                        The vulnerable code is not invoked at runtime.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="requires_configuration">
+                <xs:annotation>
+                    <xs:documentation>
+                        Exploitability requires a configurable option to be set/unset.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="requires_dependency">
+                <xs:annotation>
+                    <xs:documentation>
+                        Exploitability requires a dependency that is not present.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="requires_environment">
+                <xs:annotation>
+                    <xs:documentation>
+                        Exploitability requires a certain environment which is not present.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="protected_by_compiler">
+                <xs:annotation>
+                    <xs:documentation>
+                        Exploitability requires a compiler flag to be set/unset.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="protected_at_runtime">
+                <xs:annotation>
+                    <xs:documentation>
+                        Exploits are prevented at runtime.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="protected_at_perimeter">
+                <xs:annotation>
+                    <xs:documentation>
+                        Attacks are blocked at physical, logical, or network perimeter.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="protected_by_mitigating_control">
+                <xs:annotation>
+                    <xs:documentation>
+                        Preventative measures have been implemented that reduce the likelihood and/or impact of the vulnerability.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="scoreSourceType" final="restriction">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Specifies the severity or risk scoring methodology or standard used.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="CVSSv2">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Common Vulnerability Scoring System v2.0 standard as defined at https://www.first.org/cvss/v2/
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CVSSv3">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Common Vulnerability Scoring System v3.0 standard as defined at https://www.first.org/cvss/v3-0/
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CVSSv31">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Common Vulnerability Scoring System v3.1 standard as defined at https://www.first.org/cvss/v3-1/
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CVSSv4">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Common Vulnerability Scoring System v4.0 standard as defined at https://www.first.org/cvss/v4-0/
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OWASP">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        OWASP Risk Rating as defined at https://owasp.org/www-community/OWASP_Risk_Rating_Methodology
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SSVC">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Stakeholder Specific Vulnerability Categorization as defined at https://github.com/CERTCC/SSVC
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="other">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Another severity or risk scoring methodology
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="impactAnalysisResponsesType" final="restriction">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                The rationale of why the impact analysis state was asserted.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="can_not_fix">
+                <xs:annotation>
+                    <xs:documentation>Can not fix</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="will_not_fix">
+                <xs:annotation>
+                    <xs:documentation>Will not fix</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="update">
+                <xs:annotation>
+                    <xs:documentation>Update to a different revision or release</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="rollback">
+                <xs:annotation>
+                    <xs:documentation>Revert to a previous revision or release</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="workaround_available">
+                <xs:annotation>
+                    <xs:documentation>There is a workaround available</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="impactAnalysisAffectedStatusType" final="restriction">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                The vulnerability status of a given version or range of versions of a product. The statuses
+                'affected' and 'unaffected' indicate that the version is affected or unaffected by the vulnerability.
+                The status 'unknown' indicates that it is unknown or unspecified whether the given version is affected.
+                There can be many reasons for an 'unknown' status, including that an investigation has not been
+                undertaken or that a vendor has not disclosed the status.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="affected">
+                <xs:annotation>
+                    <xs:documentation>The version is affected by the vulnerability.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="unaffected">
+                <xs:annotation>
+                    <xs:documentation>The version is not affected by the vulnerability.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="unknown">
+                <xs:annotation>
+                    <xs:documentation>It is unknown (or unspecified) whether the given version is affected.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="formulationType">
+        <xs:annotation>
+            <xs:documentation>
+                Describes the formulation of any referencable object within the BOM,
+                including components, services, metadata, declarations, or the BOM itself. This may
+                encompass how the object was created, assembled, deployed, tested, certified, or otherwise
+                brought into its present form. Common examples include software build pipelines,
+                deployment processes, AI/ML model training, cryptographic key generation or certification,
+                and third-party audits. Processes are modeled using declared and observed formulas,
+                composed of workflows, tasks, and individual steps.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="formula" type="bom:formulaType"/>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="formulaType">
+        <xs:annotation>
+            <xs:documentation>
+                Describes workflows and resources that captures rules and other aspects of how the associated
+                BOM component or service was formed.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="components" type="bom:componentsType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Transient components that are used in tasks that constitute one or more of
+                        this formula's workflows</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="services" type="bom:servicesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Transient services that are used in tasks that constitute one or more of
+                        this formula's workflows</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="workflows" type="bom:workflowsType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>List of workflows that can be declared to accomplish specific orchestrated goals
+                        and independently triggered.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An identifier which can be used to reference the formula elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="workflowsType">
+        <xs:sequence>
+            <xs:element name="workflow" type="bom:workflowType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="workflowType">
+        <xs:sequence>
+            <xs:element name="uid" type="xs:string" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The unique identifier for the resource instance within its deployment context.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the resource instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The description of the resource instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="resourceReferences" type="bom:resourceReferencesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>References to component or service resources that are used to realize
+                        the resource instance.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="tasks" type="bom:tasksType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The tasks that comprise the workflow.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="taskDependencies" type="bom:dependenciesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The graph of dependencies between tasks within the workflow.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="taskTypes" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Indicates the types of activities performed by the set of workflow tasks.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="taskType" type="bom:taskTypeEnum" minOccurs="0" maxOccurs="unbounded" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="trigger" type="bom:triggerType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The trigger that initiated the task.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="steps" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The sequence of steps for the task.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="step" type="bom:stepType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="inputs" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Represents resources and data brought into a task at runtime by executor
+                        or task commands</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="input" type="bom:inputType" minOccurs="0" maxOccurs="unbounded" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="outputs" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Represents resources and data output from a task at runtime by executor
+                        or task commands</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="output" type="bom:outputType" minOccurs="0" maxOccurs="unbounded" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="timeStart" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The date and time (timestamp) when the task started.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="timeEnd" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The date and time (timestamp) when the task ended.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="workspaces" type="bom:workspacesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A set of named filesystem or data resource shareable by workflow tasks.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="runtimeTopology" type="bom:dependenciesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A graph of the component runtime topology for workflow's instance.
+                        A description of the runtime component and service topology.  This can describe a partial or
+                        complete topology used to host and execute the task (e.g., hardware, operating systems,
+                        configurations, etc.)</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    An identifier which can be used to reference the workflow elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="resourceReferencesType">
+        <xs:sequence>
+            <xs:element name="resourceReference" type="bom:resourceReferenceType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="resourceReferenceType">
+        <xs:sequence>
+            <xs:choice>
+                <xs:element name="ref" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            References an object by its bom-ref attribute
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:simpleType>
+                        <xs:union memberTypes="bom:refLinkType bom:bomLinkElementType"/>
+                    </xs:simpleType>
+                </xs:element>
+                <xs:element name="externalReference" type="bom:externalReference" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to an externally accessible resource.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="tasksType">
+        <xs:sequence>
+            <xs:element name="task" type="bom:taskType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="taskType">
+        <xs:sequence>
+            <xs:element name="uid" type="xs:string" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The unique identifier for the resource instance within its deployment context.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the resource instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The description of the resource instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="resourceReferences" type="bom:resourceReferencesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        References to component or service resources that are used to realize the resource instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="taskTypes" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Indicates the types of activities performed by the set of workflow tasks.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="taskType" type="bom:taskTypeEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="trigger" type="bom:triggerType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The trigger that initiated the task.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="steps" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The sequence of steps for the task.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="step" type="bom:stepType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="inputs" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Represents resources and data brought into a task at runtime by executor or task commands.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="input" type="bom:inputType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="outputs" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Represents resources and data output from a task at runtime by executor or task commands
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="output" type="bom:outputType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="timeStart" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The date and time (timestamp) when the task started.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="timeEnd" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The date and time (timestamp) when the task ended.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="workspaces" type="bom:workspacesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A set of named filesystem or data resource shareable by workflow tasks.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="runtimeTopology" type="bom:dependenciesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A graph of the component runtime topology for task's instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    An identifier which can be used to reference the task elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:simpleType name="taskTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="copy">
+                <xs:annotation>
+                    <xs:documentation>A task that copies software or data used to accomplish other tasks in the workflow.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="clone">
+                <xs:annotation>
+                    <xs:documentation>A task that clones a software repository into the workflow in order to retrieve its source code or data for use in a build step.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="lint">
+                <xs:annotation>
+                    <xs:documentation>A task that checks source code for programmatic and stylistic errors.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="scan">
+                <xs:annotation>
+                    <xs:documentation>A task that performs a scan against source code, or built or deployed components and services. Scans are typically run to gather or test for security vulnerabilities or policy compliance.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="merge">
+                <xs:annotation>
+                    <xs:documentation>A task that merges changes or fixes into source code prior to a build step in the workflow.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="build">
+                <xs:annotation>
+                    <xs:documentation>A task that builds the source code, dependencies and/or data into an artifact that can be deployed to and executed on target systems.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="test">
+                <xs:annotation>
+                    <xs:documentation>A task that verifies the functionality of a component or service.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="deliver">
+                <xs:annotation>
+                    <xs:documentation>A task that delivers a built artifact to one or more target repositories or storage systems.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="deploy">
+                <xs:annotation>
+                    <xs:documentation>A task that deploys a built artifact for execution on one or more target systems.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="release">
+                <xs:annotation>
+                    <xs:documentation>A task that releases a built, versioned artifact to a target repository or distribution system.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="clean">
+                <xs:annotation>
+                    <xs:documentation>A task that cleans unnecessary tools, build artifacts and/or data from workflow storage.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="other">
+                <xs:annotation>
+                    <xs:documentation>A workflow task that does not match current task type definitions.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="workspacesType">
+        <xs:sequence>
+            <xs:element name="workspace" type="bom:workspaceType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="workspaceType">
+        <xs:annotation>
+            <xs:documentation>
+                A named filesystem or data resource shareable by workflow tasks.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="uid" type="xs:string" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The unique identifier for the resource instance within its deployment context.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the resource instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="aliases" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The names for the workspace as referenced by other workflow tasks. Effectively, a name mapping
+                        so other tasks can use their own local name in their steps.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="alias" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The description of the resource instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="resourceReferences" type="bom:resourceReferencesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        References to component or service resources that are used to realize the resource instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="accessMode" type="bom:accessModeEnum" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Describes the read-write access control for the workspace relative to the owning resource instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="mountPath" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A path to a location on disk where the workspace will be available to the associated task's steps.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="managedDataType" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of a domain-specific data type the workspace represents. This property is for CI/CD
+                        frameworks that are able to provide access to structured, managed data at a more granular level
+                        than a filesystem.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="volumeRequest" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Identifies the reference to the request for a specific volume type and parameters.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="volume" type="bom:volumeType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Information about the actual volume instance allocated to the workspace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    An identifier which can be used to reference the workflow elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:simpleType name="accessModeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="read-only"/>
+            <xs:enumeration value="read-write"/>
+            <xs:enumeration value="read-write-once"/>
+            <xs:enumeration value="write-once"/>
+            <xs:enumeration value="write-only"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="volumeType">
+        <xs:annotation>
+            <xs:documentation>
+                An identifiable, logical unit of data storage tied to a physical device.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="uid" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The unique identifier for the volume instance within its deployment context.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the volume instance
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="mode" type="bom:volumeModeEnum" minOccurs="0" maxOccurs="1" default="filesystem">
+                <xs:annotation>
+                    <xs:documentation>
+                        The mode for the volume instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="path" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The underlying path created from the actual volume.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="sizeAllocated" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The allocated size of the volume accessible to the associated workspace. This should include
+                        the scalar size as well as IEC standard unit in either decimal or binary form.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="persistent" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Indicates if the volume persists beyond the life of the resource it is associated with.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="remote" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Indicates if the volume is remotely (i.e., network) attached.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="volumeModeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="filesystem"/>
+            <xs:enumeration value="block"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="stepType">
+        <xs:annotation>
+            <xs:documentation>
+                Executes specific commands or tools in order to accomplish its owning task as part of a sequence.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A name for the step.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A description of the step.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="commands" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Ordered list of commands or directives for the step
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="command" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="executed" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                A text representation of the executed command.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>Provides the ability to document properties in a name/value store.
+                                                This provides flexibility to include data not officially supported in the standard
+                                                without having to use additional namespaces or create extensions. Property names
+                                                of interest to the general public are encouraged to be registered in the
+                                                CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                                                Formal registration is optional.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="triggerType">
+        <xs:sequence>
+            <xs:element name="uid" type="xs:string" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The unique identifier for the resource instance within its deployment context.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the resource instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The description of the resource instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="resourceReferences" type="bom:resourceReferencesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        References to component or service resources that are used to realize the resource instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="type" type="bom:triggerTypeType" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The source type of event which caused the trigger to fire.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="event" type="bom:eventType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The event data that caused the associated trigger to activate.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="conditions" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A list of conditions used to determine if a trigger should be activated.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="condition" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    A condition that was used to determine a trigger should be activated.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Describes the set of conditions which cause the trigger to activate.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="expression" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The logical expression that was evaluated that determined the trigger should be fired.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>Provides the ability to document properties in a name/value store.
+                                                This provides flexibility to include data not officially supported in the standard
+                                                without having to use additional namespaces or create extensions. Property names
+                                                of interest to the general public are encouraged to be registered in the
+                                                CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                                                Formal registration is optional.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="timeActivated" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The date and time (timestamp) when the trigger was activated.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="inputs" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Represents resources and data brought into a task at runtime by executor or task commands
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="input" type="bom:inputType" minOccurs="0" maxOccurs="unbounded" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="outputs" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Represents resources and data output from a task at runtime by executor or task commands
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="output" type="bom:outputType" minOccurs="0" maxOccurs="unbounded" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    An identifier which can be used to reference the trigger elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:simpleType name="triggerTypeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="manual"/>
+            <xs:enumeration value="api"/>
+            <xs:enumeration value="webhook"/>
+            <xs:enumeration value="scheduled"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="eventType">
+        <xs:sequence>
+            <xs:element name="uid" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The unique identifier of the event.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A description of the event.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="timeReceived" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The date and time (timestamp) when the event was received.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="data" type="bom:attachedTextType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Encoding of the raw event data.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="source" type="bom:resourceReferenceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        References the component or service that was the source of the event
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="target" type="bom:resourceReferenceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        References the component or service that was the target of the event
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="inputType">
+        <xs:annotation>
+            <xs:documentation>
+                Type that represents various input data types and formats.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:choice>
+                <xs:element name="resource" type="bom:resourceReferenceType" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            A reference to an independent resource provided as an input to a task by the workflow runtime.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="parameters" type="bom:parametersType" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Inputs that have the form of parameters with names and values.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="environmentVars" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Inputs that have the form of parameters with names and values.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                            <!-- maxOccurs="unbounded" NEEDS to be set on the sequence, not the individual elements -->
+                            <xs:choice>
+                                <xs:element name="environmentVar" type="bom:propertyType" minOccurs="0" maxOccurs="1"/>
+                                <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                            </xs:choice>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="data" type="bom:attachedTextType" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Inputs that have the form of data.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
+            <xs:element name="source" type="bom:resourceReferenceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A references to the component or service that provided the input to the task
+                        (e.g., reference to a service with data flow value of inbound)
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="target" type="bom:resourceReferenceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A reference to the component or service that received or stored the input if not the task
+                        itself (e.g., a local, named storage workspace)
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="outputType">
+        <xs:annotation>
+            <xs:documentation>
+                Represents resources and data output from a task at runtime by executor or task commands
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:choice>
+                <xs:element name="resource" type="bom:resourceReferenceType" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            A reference to an independent resource generated as output by the task.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="environmentVars" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Outputs that have the form of environment variables.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                            <!-- maxOccurs="unbounded" NEEDS to be set on the sequence, not the individual elements -->
+                            <xs:choice>
+                                <xs:element name="environmentVar" type="bom:propertyType" minOccurs="0" maxOccurs="1"/>
+                                <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                            </xs:choice>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="data" type="bom:attachedTextType" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Outputs that have the form of data.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
+            <xs:element name="type" type="bom:outputTypeEnum" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Describes the type of data output.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="source" type="bom:resourceReferenceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Component or service that generated or provided the output from the task (e.g., a build tool)
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="target" type="bom:resourceReferenceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Component or service that received the output from the task
+                        (e.g., reference to an artifactory service with data flow value of outbound)
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:simpleType name="outputTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="artifact"/>
+            <xs:enumeration value="attestation"/>
+            <xs:enumeration value="log"/>
+            <xs:enumeration value="evidence"/>
+            <xs:enumeration value="metrics"/>
+            <xs:enumeration value="other"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="parametersType">
+        <xs:sequence>
+            <xs:element name="parameter" type="bom:parameterType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="parameterType">
+        <xs:annotation>
+            <xs:documentation>
+                A representation of a functional parameter.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the parameter.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The value of the parameter.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="dataType" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The data type of the parameter.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="cryptoPropertiesType">
+        <xs:annotation>
+            <xs:documentation>
+                Cryptographic assets have properties that uniquely define them and that make them actionable for
+                further reasoning. As an example, it makes a difference if one knows the algorithm family (e.g. AES)
+                or the specific variant or instantiation (e.g. AES-128-GCM). This is because the security level and the
+                algorithm primitive (authenticated encryption) is only defined by the definition of the algorithm variant.
+                The presence of a weak cryptographic algorithm like SHA1 vs. HMAC-SHA1 also makes a difference.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="assetType" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Cryptographic assets occur in several forms. Algorithms and protocols are most commonly
+                        implemented in specialized cryptographic libraries. They may however also be 'hardcoded'
+                        in software components. Certificates and related cryptographic material like keys, tokens,
+                        secrets or passwords are other cryptographic assets to be modelled.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="algorithm">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Mathematical function commonly used for data encryption, authentication, and
+                                    digital signatures.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="certificate">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    An electronic document that is used to provide the identity or validate a public key.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="protocol">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    A set of rules and guidelines that govern the behavior and communication with each other.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="related-crypto-material">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Other cryptographic assets that are related to algorithms, certificate, and protocols
+                                    such as keys and tokens.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="algorithmProperties" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Additional properties specific to a cryptographic algorithm.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="primitive" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Cryptographic building blocks used in higher-level cryptographic systems and
+                                    protocols. Primitives represent different cryptographic routines: deterministic
+                                    random bit generators (drbg, e.g. CTR_DRBG from NIST SP800-90A-r1), message
+                                    authentication codes (mac, e.g. HMAC-SHA-256), blockciphers (e.g. AES),
+                                    streamciphers (e.g. Salsa20), signatures (e.g. ECDSA), hash functions (e.g. SHA-256),
+                                    public-key encryption schemes (pke, e.g. RSA), extended output functions
+                                    (xof, e.g. SHAKE256), key derivation functions (e.g. pbkdf2), key agreement
+                                    algorithms (e.g. ECDH), key encapsulation mechanisms (e.g. ML-KEM), authenticated
+                                    encryption (ae, e.g. AES-GCM) and the combination of multiple algorithms
+                                    (combiner, e.g. SP800-56Cr2).
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="drbg">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Deterministic Random Bit Generator (DRBG) is a type of pseudorandom
+                                                number generator designed to produce a sequence of bits from an initial
+                                                seed value. DRBGs are commonly used in cryptographic applications where
+                                                reproducibility of random values is important.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="mac">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                In cryptography, a Message Authentication Code (MAC) is information
+                                                used for authenticating and integrity-checking a message.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="block-cipher">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                A block cipher is a symmetric key algorithm that operates on fixed-size
+                                                blocks of data. It encrypts or decrypts the data in block units,
+                                                providing confidentiality. Block ciphers are widely used in various
+                                                cryptographic modes and protocols for secure data transmission.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="stream-cipher">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                A stream cipher is a symmetric key cipher where plaintext digits are
+                                                combined with a pseudorandom cipher digit stream (keystream).
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="signature">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                In cryptography, a signature is a digital representation of a message
+                                                or data that proves its origin, identity, and integrity. Digital
+                                                signatures are generated using cryptographic algorithms and are widely
+                                                used for authentication and verification in secure communication.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="hash">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                A hash function is a mathematical algorithm that takes an input
+                                                (or 'message') and produces a fixed-size string of characters, which is
+                                                typically a hash value. Hash functions are commonly used in various
+                                                cryptographic applications, including data integrity verification and
+                                                password hashing.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="pke">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Public Key Encryption (PKE) is a type of encryption that uses a pair of
+                                                public and private keys for secure communication. The public key is used
+                                                for encryption, while the private key is used for decryption. PKE is a
+                                                fundamental component of public-key cryptography.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="xof">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                An XOF is an extendable output function that can take arbitrary input
+                                                and creates a stream of output, up to a limit determined by the size of
+                                                the internal state of the hash function that underlies the XOF.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="kdf">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                A Key Derivation Function (KDF) derives key material from another source
+                                                of entropy while preserving the entropy of the input.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="key-agree">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                In cryptography, a key-agreement is a protocol whereby two or more
+                                                parties agree on a cryptographic key in such a way that both influence
+                                                the outcome.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="kem">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                A Key Encapsulation Mechanism (KEM) algorithm is a mechanism for
+                                                transporting random keying material to a recipient using the recipient's
+                                                public key.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="ae">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Authenticated Encryption (AE) is a cryptographic process that provides
+                                                both confidentiality and data integrity. It ensures that the encrypted
+                                                data has not been tampered with and comes from a legitimate source.
+                                                AE is commonly used in secure communication protocols.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="combiner">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                A combiner aggregates many candidates for a cryptographic primitive and
+                                                generates a new candidate for the same primitive.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="key-wrap">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Key-wrap is a cryptographic technique used to securely encrypt and
+                                                protect cryptographic keys using algorithms like AES.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="other">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Another primitive type.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="unknown">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The primitive is not known.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="algorithmFamily" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    A valid algorithm family identifier.
+                                    If specified, this value must be one of the enumeration of valid algorithm Family identifiers defined in the `cryptography-defs.schema.json` subschema. A corresponding schema for XML is not available.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="parameterSetIdentifier" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    An identifier for the parameter set of the cryptographic algorithm. Examples: in
+                                    AES128, '128' identifies the key length in bits, in SHA256, '256' identifies the
+                                    digest length, '128' in SHAKE128 identifies its maximum security level in bits, and
+                                    'SHA2-128s' identifies a parameter set used in SLH-DSA (FIPS205).
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="curve" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    DEPRECATED - DO NOT USE. This will be removed in a future version. Use `./ellipticCurve` instead.
+                                    The specific underlying Elliptic Curve (EC) definition employed which is an indicator
+                                    of the level of security strength, performance and complexity. Absent an
+                                    authoritative source of curve names, CycloneDX recommends use of curve names as
+                                    defined at https://neuromancer.sk/std/, the source from which can be found at
+                                    https://github.com/J08nY/std-curves.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="ellipticCurve" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The specific underlying Elliptic Curve (EC) definition employed which is an indicator of the level of security strength, performance and complexity.
+                                    If specified, this value must be one of the enumeration of valid elliptic curves identifiers defined in the `cryptography-defs.schema.json` subschema. A corresponding schema for XML is not available.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="executionEnvironment" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The target and execution environment in which the algorithm is implemented in.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="software-plain-ram">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                A software implementation running in plain unencrypted RAM.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="software-encrypted-ram">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                A software implementation running in encrypted RAM.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration><xs:enumeration value="software-tee">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            A software implementation running in a trusted execution environment.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:enumeration><xs:enumeration value="hardware">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            A hardware implementation.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:enumeration><xs:enumeration value="other">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Another implementation environment.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:enumeration><xs:enumeration value="unknown">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The execution environment is not known.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:enumeration>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="implementationPlatform" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The target platform for which the algorithm is implemented. The implementation can
+                                    be 'generic', running on any platform or for a specific platform.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="generic"/>
+                                    <xs:enumeration value="x86_32"/>
+                                    <xs:enumeration value="x86_64"/>
+                                    <xs:enumeration value="armv7-a"/>
+                                    <xs:enumeration value="armv7-m"/>
+                                    <xs:enumeration value="armv8-a"/>
+                                    <xs:enumeration value="armv8-m"/>
+                                    <xs:enumeration value="armv9-a"/>
+                                    <xs:enumeration value="armv9-m"/>
+                                    <xs:enumeration value="s390x"/>
+                                    <xs:enumeration value="ppc64"/>
+                                    <xs:enumeration value="ppc64le"/>
+                                    <xs:enumeration value="other"/>
+                                    <xs:enumeration value="unknown"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="certificationLevel" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The certification that the implementation of the cryptographic algorithm has
+                                    received, if any. Certifications include revisions and levels of FIPS 140 or
+                                    Common Criteria of different Extended Assurance Levels (CC-EAL).
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="none">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                No certification obtained
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="fips140-1-l1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                FIPS 140-1 Level 1
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="fips140-1-l2">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                FIPS 140-1 Level 2
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="fips140-1-l3">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                FIPS 140-1 Level 3
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="fips140-1-l4">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                FIPS 140-1 Level 4
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="fips140-2-l1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                FIPS 140-2 Level 1
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="fips140-2-l2">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                FIPS 140-2 Level 2
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="fips140-2-l3">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                FIPS 140-2 Level 3
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="fips140-2-l4">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                FIPS 140-2 Level 4
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="fips140-3-l1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                FIPS 140-3 Level 1
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="fips140-3-l2">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                FIPS 140-3 Level 2
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="fips140-3-l3">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                FIPS 140-3 Level 3
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="fips140-3-l4">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                FIPS 140-3 Level 4
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 1
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal1+">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 1 (Augmented)
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal2">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 2
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal2+">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 2 (Augmented)
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal3">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 3
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal3+">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 3 (Augmented)
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal4">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 4
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal4+">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 4 (Augmented)
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal5">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 5
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal5+">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 5 (Augmented)
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal6">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 6
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal6+">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 6 (Augmented)
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal7">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 7
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal7+">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 7 (Augmented)
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="other">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Another certification
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="unknown">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The certification level is not known
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="mode" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The mode of operation in which the cryptographic algorithm (block cipher) is used.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="cbc">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Cipher block chaining
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="ecb">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Electronic codebook
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="ccm">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Counter with cipher block chaining message authentication code
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="gcm">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Galois/counter
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cfb">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Cipher feedback
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="ofb">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Output feedback
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="ctr">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Counter
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="other">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Another mode of operation
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="unknown">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The mode of operation is not known
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="padding" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The padding scheme that is used for the cryptographic algorithm.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="pkcs5">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Password-Based Cryptography Specification #5
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="pkcs7">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Public Key Cryptography Standard: Cryptographic Message Syntax
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="pkcs1v15">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Public Key Cryptography Standard: RSA Cryptography v1.5
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="oaep">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Optimal asymmetric encryption padding
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="raw">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Raw
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="other">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Another padding scheme
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="unknown">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The padding scheme is not known
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="cryptoFunctions" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The cryptographic functions implemented by the cryptographic algorithm.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="cryptoFunction" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                                <xs:enumeration value="generate"/>
+                                                <xs:enumeration value="keygen"/>
+                                                <xs:enumeration value="encrypt"/>
+                                                <xs:enumeration value="decrypt"/>
+                                                <xs:enumeration value="digest"/>
+                                                <xs:enumeration value="tag"/>
+                                                <xs:enumeration value="keyderive"/>
+                                                <xs:enumeration value="sign"/>
+                                                <xs:enumeration value="verify"/>
+                                                <xs:enumeration value="encapsulate"/>
+                                                <xs:enumeration value="decapsulate"/>
+                                                <xs:enumeration value="other"/>
+                                                <xs:enumeration value="unknown"/>
+                                            </xs:restriction>
+                                        </xs:simpleType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="classicalSecurityLevel" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The classical security level that a cryptographic algorithm provides (in bits).
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:integer">
+                                    <xs:minInclusive value="0"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="nistQuantumSecurityLevel" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The NIST security strength category as defined in
+                                    https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/evaluation-criteria/security-(evaluation-criteria).
+                                    A value of 0 indicates that none of the categories are met.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:integer">
+                                    <xs:minInclusive value="0"/>
+                                    <xs:maxInclusive value="6"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="certificateProperties" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Properties for cryptographic assets of asset type 'certificate'
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="serialNumber" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The serial number is a unique identifier for the certificate issued by a CA.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="subjectName" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The subject name for the certificate
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="issuerName" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The issuer name for the certificate
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="notValidBefore" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The date and time according to ISO-8601 standard from which the certificate is valid
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="notValidAfter" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The date and time according to ISO-8601 standard from which the certificate is not valid anymore
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="signatureAlgorithmRef" type="bom:refType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    DEPRECATED - DO NOT USE. This will be removed in a future version. Use `./relatedCryptographicAssets` instead.
+                                    The bom-ref to signature algorithm used by the certificate
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="subjectPublicKeyRef" type="bom:refType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    DEPRECATED - DO NOT USE. This will be removed in a future version. Use `./relatedCryptographicAssets` instead.
+                                    The bom-ref to the public key of the subject
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="certificateFormat" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The format of the certificate. Examples include X.509, PEM, DER, and CVC
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="certificateExtension" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    DEPRECATED - DO NOT USE. This will be removed in a future version. Use `./certificateFileExtension` instead.
+                                    The file extension of the certificate. Examples include crt, pem, cer, der, and p12.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="certificateFileExtension" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The file extension of the certificate. Examples include crt, pem, cer, der, and p12.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="fingerprint" type="bom:hashType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The fingerprint is a cryptographic hash of the certificate excluding it's signature.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="certificateState" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The certificate lifecycle is a comprehensive process that manages digital
+                                    certificates from their initial creation to eventual expiration or revocation.
+                                    It typically involves several stages.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:choice>
+                                    <!-- Pre-Defined State -->
+                                    <xs:sequence>
+                                        <xs:element name="state" minOccurs="1" maxOccurs="1">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    A pre-defined state in the certificate lifecycle.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                            <xs:simpleType>
+                                                <xs:restriction base="xs:string">
+                                                    <xs:enumeration value="pre-activation">
+                                                        <xs:annotation>
+                                                            <xs:documentation>
+                                                                The certificate has been issued by the issuing
+                                                                certificate authority (CA) but has not been authorized
+                                                                for use.
+                                                            </xs:documentation>
+                                                        </xs:annotation>
+                                                    </xs:enumeration>
+                                                    <xs:enumeration value="active">
+                                                        <xs:annotation>
+                                                            <xs:documentation>
+                                                                The certificate may be used to cryptographically protect
+                                                                information, cryptographically process previously protected
+                                                                information, or both.
+                                                            </xs:documentation>
+                                                        </xs:annotation>
+                                                    </xs:enumeration>
+                                                    <xs:enumeration value="suspended">
+                                                        <xs:annotation>
+                                                            <xs:documentation>
+                                                                Certificates in the deactivated state shall not be used
+                                                                to apply cryptographic protection but, in some cases,
+                                                                may be used to process cryptographically protected
+                                                                information.
+                                                            </xs:documentation>
+                                                        </xs:annotation>
+                                                    </xs:enumeration>
+                                                    <xs:enumeration value="deactivated">
+                                                        <xs:annotation>
+                                                            <xs:documentation>
+                                                                The use of a certificate may be suspended for several
+                                                                possible reasons.
+                                                            </xs:documentation>
+                                                        </xs:annotation>
+                                                    </xs:enumeration>
+                                                    <xs:enumeration value="revoked">
+                                                        <xs:annotation>
+                                                            <xs:documentation>
+                                                                A revoked certificate is a digital certificate that has
+                                                                been invalidated by the issuing certificate authority (CA)
+                                                                before its scheduled expiration date.
+                                                            </xs:documentation>
+                                                        </xs:annotation>
+                                                    </xs:enumeration>
+                                                    <xs:enumeration value="destroyed">
+                                                        <xs:annotation>
+                                                            <xs:documentation>
+                                                                The certificate has been destroyed.
+                                                            </xs:documentation>
+                                                        </xs:annotation>
+                                                    </xs:enumeration>
+                                                </xs:restriction>
+                                            </xs:simpleType>
+                                        </xs:element>
+                                        <xs:element name="reason" type="xs:string" minOccurs="0" maxOccurs="1">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    A reason for the certificate being in this state.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:element>
+                                    </xs:sequence>
+                                    <!-- Custom State -->
+                                    <xs:sequence>
+                                        <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    The name of the certificate lifecycle state.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:element>
+                                        <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    The description of the certificate lifecycle state.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:element>
+                                        <xs:element name="reason" type="xs:string" minOccurs="0" maxOccurs="1">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    A reason for the certificate being in this state.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:element>
+                                    </xs:sequence>
+                                </xs:choice>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="creationDate" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The date and time (timestamp) when the certificate was created or pre-activated.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="activationDate" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The date and time (timestamp) when the certificate was activated.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="deactivationDate" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The date and time (timestamp) when the related certificate was deactivated.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="revocationDate" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The date and time (timestamp) when the certificate was revoked.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="destructionDate" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The date and time (timestamp) when the certificate was destroyed.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="certificateExtensions" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    A certificate extension is a field that provides additional information about the certificate or its use. Extensions are used to convey additional information beyond the standard fields.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="certificateExtension" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Extension: This can be either a common extension
+                                                (with a well-known name and value) or a custom extension
+                                                (for application or vendor-specific data).
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:choice>
+                                                <!-- Common Extensions -->
+                                                <xs:sequence>
+                                                    <xs:element name="commonExtensionName" minOccurs="1" maxOccurs="1">
+                                                        <xs:annotation>
+                                                            <xs:documentation>
+                                                                The name of the extension.
+                                                            </xs:documentation>
+                                                        </xs:annotation>
+                                                        <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                                <xs:enumeration value="basicConstraints">
+                                                                    <xs:annotation>
+                                                                        <xs:documentation>
+                                                                            Specifies whether a certificate can be used as a CA certificate or not.
+                                                                        </xs:documentation>
+                                                                    </xs:annotation>
+                                                                </xs:enumeration>
+                                                                <xs:enumeration value="keyUsage">
+                                                                    <xs:annotation>
+                                                                        <xs:documentation>
+                                                                            Specifies the allowed uses of the public key in the certificate.
+                                                                        </xs:documentation>
+                                                                    </xs:annotation>
+                                                                </xs:enumeration>
+                                                                <xs:enumeration value="extendedKeyUsage">
+                                                                    <xs:annotation>
+                                                                        <xs:documentation>
+                                                                            Specifies additional purposes for which the public key can be used.
+                                                                        </xs:documentation>
+                                                                    </xs:annotation>
+                                                                </xs:enumeration>
+                                                                <xs:enumeration value="subjectAlternativeName">
+                                                                    <xs:annotation>
+                                                                        <xs:documentation>
+                                                                            Allows inclusion of additional names to identify the entity associated with the certificate.
+                                                                        </xs:documentation>
+                                                                    </xs:annotation>
+                                                                </xs:enumeration>
+                                                                <xs:enumeration value="authorityKeyIdentifier">
+                                                                    <xs:annotation>
+                                                                        <xs:documentation>
+                                                                            Identifies the public key of the CA that issued the certificate.
+                                                                        </xs:documentation>
+                                                                    </xs:annotation>
+                                                                </xs:enumeration>
+                                                                <xs:enumeration value="subjectKeyIdentifier">
+                                                                    <xs:annotation>
+                                                                        <xs:documentation>
+                                                                            Identifies the public key associated with the entity the certificate was issued to.
+                                                                        </xs:documentation>
+                                                                    </xs:annotation>
+                                                                </xs:enumeration>
+                                                                <xs:enumeration value="authorityInformationAccess">
+                                                                    <xs:annotation>
+                                                                        <xs:documentation>
+                                                                            Contains CA issuers and OCSP information.
+                                                                        </xs:documentation>
+                                                                    </xs:annotation>
+                                                                </xs:enumeration>
+                                                                <xs:enumeration value="certificatePolicies">
+                                                                    <xs:annotation>
+                                                                        <xs:documentation>
+                                                                            Defines the policies under which the certificate was issued and can be used.
+                                                                        </xs:documentation>
+                                                                    </xs:annotation>
+                                                                </xs:enumeration>
+                                                                <xs:enumeration value="crlDistributionPoints">
+                                                                    <xs:annotation>
+                                                                        <xs:documentation>
+                                                                            Contains one or more URLs where a Certificate Revocation List (CRL) can be obtained.
+                                                                        </xs:documentation>
+                                                                    </xs:annotation>
+                                                                </xs:enumeration>
+                                                                <xs:enumeration value="signedCertificateTimestamp">
+                                                                    <xs:annotation>
+                                                                        <xs:documentation>
+                                                                            Shows that the certificate has been publicly logged, which helps prevent the issuance of rogue certificates by a CA. Log ID, timestamp and signature as proof.
+                                                                        </xs:documentation>
+                                                                    </xs:annotation>
+                                                                </xs:enumeration>
+                                                            </xs:restriction>
+                                                        </xs:simpleType>
+                                                    </xs:element>
+                                                    <xs:element name="commonExtensionValue" type="xs:string" minOccurs="1" maxOccurs="1">
+                                                        <xs:annotation>
+                                                            <xs:documentation>
+                                                                The value of the certificate extension.
+                                                            </xs:documentation>
+                                                        </xs:annotation>
+                                                    </xs:element>
+                                                </xs:sequence>
+                                                <!-- Custom Extensions -->
+                                                <xs:sequence>
+                                                    <xs:element name="customExtensionName" type="xs:string" minOccurs="1" maxOccurs="1">
+                                                        <xs:annotation>
+                                                            <xs:documentation>
+                                                                The name for the custom certificate extension.
+                                                            </xs:documentation>
+                                                        </xs:annotation>
+                                                    </xs:element>
+                                                    <xs:element name="customExtensionValue" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                        <xs:annotation>
+                                                            <xs:documentation>
+                                                                The description of the custom certificate extension.
+                                                            </xs:documentation>
+                                                        </xs:annotation>
+                                                    </xs:element>
+                                                </xs:sequence>
+                                            </xs:choice>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="relatedCryptographicAssets" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    A list of cryptographic assets related to this component.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="relatedCryptographicAsset" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                A cryptographic asset related to this component.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            Specifies the mechanism by which the cryptographic asset is secured by.
+                                                            Examples: "publicKey", "privateKey", "algorithm"
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="ref" type="bom:refType" minOccurs="0">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The bom-ref to cryptographic asset.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="relatedCryptoMaterialProperties" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Properties for cryptographic assets of asset type 'relatedCryptoMaterial'
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="type" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The type for the related cryptographic material
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="private-key"/>
+                                    <xs:enumeration value="public-key"/>
+                                    <xs:enumeration value="secret-key"/>
+                                    <xs:enumeration value="key"/>
+                                    <xs:enumeration value="ciphertext"/>
+                                    <xs:enumeration value="signature"/>
+                                    <xs:enumeration value="digest"/>
+                                    <xs:enumeration value="initialization-vector"/>
+                                    <xs:enumeration value="nonce"/>
+                                    <xs:enumeration value="seed"/>
+                                    <xs:enumeration value="salt"/>
+                                    <xs:enumeration value="shared-secret"/>
+                                    <xs:enumeration value="tag"/>
+                                    <xs:enumeration value="additional-data"/>
+                                    <xs:enumeration value="password"/>
+                                    <xs:enumeration value="credential"/>
+                                    <xs:enumeration value="token"/>
+                                    <xs:enumeration value="other"/>
+                                    <xs:enumeration value="unknown"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="id" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The unique identifier for the related cryptographic material.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="state" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The key state as defined by NIST SP 800-57.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="pre-activation"/>
+                                    <xs:enumeration value="active"/>
+                                    <xs:enumeration value="suspended"/>
+                                    <xs:enumeration value="deactivated"/>
+                                    <xs:enumeration value="compromised"/>
+                                    <xs:enumeration value="destroyed"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="algorithmRef" type="bom:refType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The bom-ref to the algorithm used to generate the related cryptographic material.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="creationDate" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The date and time (timestamp) when the related cryptographic material was created.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="activationDate" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The date and time (timestamp) when the related cryptographic material was activated.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="updateDate" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The date and time (timestamp) when the related cryptographic material was updated.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="expirationDate" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The date and time (timestamp) when the related cryptographic material expires.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The associated value of the cryptographic material.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="size" type="xs:integer" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The size of the cryptographic asset (in bits).
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="format" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The format of the related cryptographic material (e.g. P8, PEM, DER).
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="securedBy" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The mechanism by which the cryptographic asset is secured by.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="mechanism" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Specifies the mechanism by which the cryptographic asset is secured by.
+                                                Examples include HSM, TPM, XGX, Software, and None.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="algorithmRef" type="bom:refType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The bom-ref to the algorithm.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="fingerprint" type="bom:hashType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The fingerprint is a cryptographic hash of the related cryptographic material, excluding it's signature.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="relatedCryptographicAssets" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    A list of cryptographic assets related to this component.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="relatedCryptographicAsset" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                A cryptographic asset related to this component.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            Specifies the mechanism by which the cryptographic asset is secured by.
+                                                            Examples: "publicKey", "privateKey", "algorithm"
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="ref" type="bom:refType" minOccurs="0">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The bom-ref to cryptographic asset.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="protocolProperties" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Properties specific to cryptographic assets of type: 'protocol'.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="type" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The concrete protocol type.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="tls">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Transport Layer Security
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="ssh">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Secure Shell
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="ipsec">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Internet Protocol Security
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="ike">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Internet Key Exchange
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="sstp">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Secure Socket Tunneling Protocol
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="wpa">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Wi-Fi Protected Access
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="dtls">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Datagram Transport Layer Security
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="quic">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Quick UDP Internet Connections
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="eap-aka">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Extensible Authentication Protocol variant
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="eap-aka-prime">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Enhanced version of EAP-AKA
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="prins">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Protection of Inter-Network Signaling
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="5g-aka">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Authentication and Key Agreement for 5G
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="other">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Another protocol type
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="unknown">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The protocol type is not known
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="version" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The version of the protocol. Examples include 1.0, 1.2, and 1.99.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="cipherSuites" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    A list of cipher suites related to the protocol.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="cipherSuite" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            A common name for the cipher suite. For example: TLS_DHE_RSA_WITH_AES_128_CCM
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="algorithms" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            A list of algorithms related to the cipher suite.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="algorithm" type="bom:refType" minOccurs="0" maxOccurs="unbounded">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The bom-ref to algorithm cryptographic asset.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="identifiers" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            A list of common identifiers for the cipher suite.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="identifier" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        Cipher suite identifier. Examples include 0xC0 and 0x9E.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="tlsGroups" minOccurs="0">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            A list of TLS named groups (formerly known as curves) for
+                                                            this cipher suite. These groups define the parameters for
+                                                            key exchange algorithms like ECDHE.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="group" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The name of the TLS group.
+                                                                        Example values: x25519, ffdhe2048
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="tlsSignatureSchemes" minOccurs="0">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            A list of signature schemes supported for cipher suite.
+                                                            These schemes specify the algorithms used for digital
+                                                            signatures in TLS handshakes and certificate verification.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="signatureScheme" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The name of the TLS signature scheme.
+                                                                        Example values: ecdsa_secp256r1_sha256, rsa_pss_rsae_sha256, ed25519
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="ikev2TransformTypes" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The IKEv2 transform types supported (types 1-4), defined in RFC7296 section 3.3.2,
+                                    and additional properties.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="encr" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Transform Type 1: encryption algorithms
+
+                                                EITHER a detailed description (PREFERRED)
+                                                OR a single string representing a "bom:refType" (DEPRECATED This will be removed in a future version.)
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType mixed="true">
+                                            <xs:sequence>
+                                                <xs:element name="name" type="xs:string" minOccurs="0">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            A name for the encryption method.
+                                                            Example: ENCR_AES_GCM_16
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="keyLength" type="xs:integer" minOccurs="0">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The key length of the encryption algorithm.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="algorithm" type="bom:refType" minOccurs="0">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The bom-ref to algorithm cryptographic asset.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="prf" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Transform Type 2: pseudorandom functions
+
+                                                EITHER a detailed description (PREFERRED)
+                                                OR a single string representing a "bom:refType" (DEPRECATED This will be removed in a future version.)
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType mixed="true">
+                                            <xs:sequence>
+                                                <xs:element name="name" type="xs:string" minOccurs="0">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            A name for the pseudorandom function.
+                                                            Example: PRF_HMAC_SHA2_256
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="algorithm" type="bom:refType" minOccurs="0">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The bom-ref to algorithm cryptographic asset.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="integ" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Transform Type 3: integrity algorithms
+
+                                                EITHER a detailed description (PREFERRED)
+                                                OR a single string representing a "bom:refType" (DEPRECATED This will be removed in a future version.)
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType mixed="true">
+                                            <xs:sequence>
+                                                <xs:element name="name" type="xs:string" minOccurs="0">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            A name for the integrity algorithm.
+                                                            Example: AUTH_HMAC_SHA2_256_128
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="algorithm" type="bom:refType" minOccurs="0">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The bom-ref to algorithm cryptographic asset.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="ke" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Transform Type 4: Key Exchange Method (KE) per RFC9370, formerly called Diffie-Hellman Group (D-H)
+
+                                                EITHER a detailed description (PREFERRED)
+                                                OR a single string representing a "bom:refType" (DEPRECATED This will be removed in a future version.)
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType mixed="true">
+                                            <xs:sequence>
+                                                <xs:element name="group" type="xs:integer" minOccurs="0">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            A group identifier for the key exchange algorithm.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="algorithm" type="bom:refType" minOccurs="0">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The bom-ref to algorithm cryptographic asset.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="esn" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Specifies if an Extended Sequence Number (ESN) is used.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="auth" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                IKEv2 Authentication method
+
+                                                EITHER a detailed description (PREFERRED)
+                                                OR a single string representing a "bom:refType" (DEPRECATED This will be removed in a future version.)
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType mixed="true">
+                                            <xs:sequence>
+                                                <xs:element name="name" type="xs:string" minOccurs="0">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            A name for the authentication method.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="algorithm" type="bom:refType" minOccurs="0">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The bom-ref to algorithm cryptographic asset.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="cryptoRef" type="bom:refType" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>A protocol-related cryptographic assets</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="oid" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The object identifier (OID) of the cryptographic asset.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="declarationsType">
+        <xs:sequence>
+            <xs:element name="assessors" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The list of assessors evaluating claims and determining conformance to requirements and confidence in that assessment.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="assessor" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The assessor who evaluates claims and determines conformance to requirements and confidence in that assessment.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="thirdParty" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The boolean indicating if the assessor is outside the organization generating claims. A value of false indicates a self assessor.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="organization" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The entity issuing the assessment.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                                <xs:attribute name="bom-ref" type="bom:refType">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            An identifier which can be used to reference the object elsewhere in the BOM.
+                                            Every `bom-ref` must be unique within the BOM.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:anyAttribute namespace="##other" processContents="lax">
+                                    <xs:annotation>
+                                        <xs:documentation>User-defined attributes may be used on this element as long as they
+                                            do not have the same name as an existing attribute used by the schema.</xs:documentation>
+                                    </xs:annotation>
+                                </xs:anyAttribute>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="attestations" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The list of attestations asserted by an assessor that maps requirements to claims.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="attestation" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    An attestation asserted by an assessor that maps requirements to claims.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="summary" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The short description explaining the main points of the attestation.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="assessor" type="bom:refLinkType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The `bom-ref` to the assessor asserting the attestation.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="map" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The grouping of requirements to claims and the attestors declared conformance and confidence thereof.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="requirement" type="bom:refLinkType" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The `bom-ref` to the requirement being attested to.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="claims" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The list of `bom-ref` to the claims being attested to.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="claim" type="bom:refLinkType" minOccurs="0" maxOccurs="unbounded">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The `bom-ref` to the claim being attested to.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="counterClaims" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The list of `bom-ref` to the counter claims being attested to.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="counterClaim" type="bom:refLinkType" minOccurs="0" maxOccurs="unbounded">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The `bom-ref` to the counter claim being attested to.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="conformance" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The conformance of the claim meeting a requirement.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="score">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The conformance of the claim between and inclusive of 0 and 1, where 1 is 100% conformance.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                                <xs:simpleType>
+                                                                    <xs:restriction base="xs:decimal">
+                                                                        <xs:minInclusive value="0"/>
+                                                                        <xs:maxInclusive value="1"/>
+                                                                    </xs:restriction>
+                                                                </xs:simpleType>
+                                                            </xs:element>
+                                                            <xs:element name="rationale" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The rationale for the score of conformance.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                            <xs:element name="mitigationStrategies" minOccurs="0" maxOccurs="1">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The list of  `bom-ref` to the evidence provided describing the
+                                                                        mitigation strategies. Each mitigation strategy should include an
+                                                                        explanation of how any weaknesses in the evidence will be mitigated.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                                <xs:complexType>
+                                                                    <xs:sequence>
+                                                                        <xs:element name="mitigationStrategy" type="bom:refLinkType" minOccurs="0" maxOccurs="unbounded"/>
+                                                                    </xs:sequence>
+                                                                </xs:complexType>
+                                                            </xs:element>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="confidence" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The confidence of the claim meeting the requirement.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="score">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The confidence of the claim between and inclusive of 0 and 1, where 1 is 100% confidence.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                                <xs:simpleType>
+                                                                    <xs:restriction base="xs:decimal">
+                                                                        <xs:minInclusive value="0"/>
+                                                                        <xs:maxInclusive value="1"/>
+                                                                    </xs:restriction>
+                                                                </xs:simpleType>
+                                                            </xs:element>
+                                                            <xs:element name="rationale" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The rationale for the confidence score.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:any>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="claims" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The list of claims.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="claim" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="target" type="bom:refLinkType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The `bom-ref` to a target representing a specific system, application,
+                                                API, module, team, person, process, business unit, company, etc...
+                                                that this claim is being applied to.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="predicate" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The specific statement or assertion about the target.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="mitigationStrategies" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The list of  `bom-ref` to the evidence provided describing the
+                                                mitigation strategies. Each mitigation strategy should include an
+                                                explanation of how any weaknesses in the evidence will be mitigated.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="mitigationStrategy" type="bom:refLinkType" minOccurs="0" maxOccurs="unbounded"/>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="reasoning" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The written explanation of why the evidence provided substantiates the claim.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="evidence" type="bom:refLinkType" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The list of `bom-ref` to evidence that supports this claim.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="counterEvidence" type="bom:refLinkType" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The list of `bom-ref` to counterEvidence that supports this claim.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="externalReferences" type="bom:externalReferences" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>Provides the ability to document external references related to the claim the BOM describes.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:any>
+                                </xs:sequence>
+                                <xs:attribute name="bom-ref" type="bom:refType">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            An identifier which can be used to reference the object elsewhere
+                                            in the BOM. Every `bom-ref` must be unique within the BOM.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:anyAttribute namespace="##other" processContents="lax">
+                                    <xs:annotation>
+                                        <xs:documentation>User-defined attributes may be used on this element as long as they
+                                            do not have the same name as an existing attribute used by the schema.</xs:documentation>
+                                    </xs:annotation>
+                                </xs:anyAttribute>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="evidence" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The list of evidence
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="evidence" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The list of evidence
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="propertyName" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The reference to the property name as defined in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy/).
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The written description of what this evidence is and how it was created.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="data" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The output or analysis that supports claims.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The name of the data.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="contents" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The contents or references to the contents of the data being described.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="attachment" type="bom:attachedTextType" minOccurs="0" maxOccurs="1">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>A way to include textual or encoded data.</xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                            <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>The URL to where the data can be retrieved.</xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="classification" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            Data classification tags data according to its type, sensitivity, and value if altered, stolen, or destroyed.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="sensitiveData" minOccurs="0" maxOccurs="unbounded">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            A description of any sensitive data.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="governance" type="bom:dataGovernance" minOccurs="0" maxOccurs="1" />
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="created" type="xs:dateTime" minOccurs="0">
+                                        <xs:annotation>
+                                            <xs:documentation>The date and time (timestamp) when the evidence was created.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="expires" type="xs:dateTime" minOccurs="0">
+                                        <xs:annotation>
+                                            <xs:documentation>The date and time (timestamp) when the evidence is no longer valid.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="author" type="bom:organizationalContact" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>The author of the evidence.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="reviewer" type="bom:organizationalContact" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>The reviewer of the evidence.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:any>
+                                </xs:sequence>
+                                <xs:attribute name="bom-ref" type="bom:refType">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            A identifier which can be used to reference the object elsewhere
+                                            in the BOM. Every `bom-ref` must be unique within the BOM.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:anyAttribute namespace="##other" processContents="lax">
+                                    <xs:annotation>
+                                        <xs:documentation>User-defined attributes may be used on this element as long as they
+                                            do not have the same name as an existing attribute used by the schema.</xs:documentation>
+                                    </xs:annotation>
+                                </xs:anyAttribute>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="targets" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The list of targets which claims are made against.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="organizations" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The list of organizations which claims are made against.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="organization" type="bom:organizationalEntity" minOccurs="0" maxOccurs="unbounded" />
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="components" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The list of components which claims are made against.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="component" type="bom:component" minOccurs="0" maxOccurs="unbounded" />
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="services" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The list of services which claims are made against.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="service" type="bom:service" minOccurs="0" maxOccurs="unbounded" />
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="affirmation" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A concise statement affirmed by an individual regarding all declarations, often used for third-party auditor acceptance or recipient acknowledgment.
+                        It includes a list of authorized signatories who assert the validity of the document on behalf of the organization.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="statement" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The brief statement affirmed by an individual regarding all declarations.
+                                    This could be an affirmation of acceptance by a third-party auditor or receiving
+                                    individual of a file. For example: "I certify, to the best of my knowledge, that all information is correct."
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="signatories" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The list of signatories authorized on behalf of an organization to assert validity of this document.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="signatory" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The signatory's name.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="role" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The signatory's role within an organization.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="organization" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The signatory's organization.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="externalReference" type="bom:externalReference" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            An External reference provide a way to document systems, sites, and information that may be relevant, but are not included with the BOM. They may also establish specific relationships within or external to the BOM.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:any>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:any>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="definitionsType">
+        <xs:annotation>
+            <xs:documentation>
+                A collection of reusable objects that are defined and may be used elsewhere in the BOM.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="standards" type="bom:standardsType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="patents" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:choice minOccurs="0" maxOccurs="unbounded">
+                            <xs:element name="patent" type="bom:patentType"/>
+                            <xs:element name="patentFamily" type="bom:patentFamilyType"/>
+                        </xs:choice>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="standardsType">
+        <xs:annotation>
+            <xs:documentation>
+                The list of standards which may consist of regulations, industry or organizational-specific standards, maturity models, best practices, or any other requirements which can be evaluated against or attested to.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="standard" type="bom:standard"/>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="standard">
+        <xs:annotation>
+            <xs:documentation>
+                A standard may consist of regulations, industry or organizational-specific standards, maturity models, best practices, or any other requirements which can be evaluated against or attested to.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="name" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the standard. This will often be a shortened, single name of the standard.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="version" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>
+                        The version of the standard.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>
+                        The description of the standard.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="owner" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>
+                        The owner of the standard, often the entity responsible for its release.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="requirements" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The list of requirements comprising the standard.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="requirement" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="identifier" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The unique identifier used in the standard to identify a specific requirement. This should match what is in the standard and should not be the requirements bom-ref.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="title" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The title of the requirement.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="text" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The textual content of the requirement.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="descriptions" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The supplemental text that provides additional guidance or context to the requirement, but is not directly part of the requirement.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="openCre" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The Common Requirements Enumeration (CRE) identifier(s). CRE is a structured and standardized framework for uniting security standards and guidelines. CRE links each section of a resource to a shared topic identifier (a Common Requirement). Through this shared topic link, all resources map to each other. Use of CRE promotes clear and unambiguous communication among stakeholders.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                                <xs:pattern value="CRE:[0-9]+-[0-9]+"/>
+                                            </xs:restriction>
+                                        </xs:simpleType>
+                                    </xs:element>
+                                    <xs:element name="parent" type="bom:refLinkType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The `bom-ref` to a parent requirement. This establishes a hierarchy of requirements. Top-level requirements must not define a parent. Only child requirements should define parents.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>Provides the ability to document properties in a name/value store.
+                                                This provides flexibility to include data not officially supported in the standard
+                                                without having to use additional namespaces or create extensions. Property names
+                                                of interest to the general public are encouraged to be registered in the
+                                                CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                                                Formal registration is optional.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="externalReferences" type="bom:externalReferences" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>Provides the ability to document external references related to the BOM or
+                                                to the project the BOM describes.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                                <xs:attribute name="bom-ref" type="bom:refType">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            An identifier which can be used to reference the object elsewhere
+                                            in the BOM. Every `bom-ref` must be unique within the BOM.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:anyAttribute namespace="##other" processContents="lax">
+                                    <xs:annotation>
+                                        <xs:documentation>User-defined attributes may be used on this element as long as they
+                                            do not have the same name as an existing attribute used by the schema.</xs:documentation>
+                                    </xs:annotation>
+                                </xs:anyAttribute>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="levels" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The list of levels associated with the standard. Some standards have different levels of compliance.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="level" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="identifier" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The identifier used in the standard to identify a specific level.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="title" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The title of the level.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The description of the level.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="requirements" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The list of requirement `bom-ref`s that comprise the level.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="requirement" type="bom:refLinkType" minOccurs="0" maxOccurs="unbounded"/>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                                <xs:attribute name="bom-ref" type="bom:refType">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            An identifier which can be used to reference the object elsewhere
+                                            in the BOM. Every `bom-ref` must be unique within the BOM.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:anyAttribute namespace="##other" processContents="lax">
+                                    <xs:annotation>
+                                        <xs:documentation>User-defined attributes may be used on this element as long as they
+                                            do not have the same name as an existing attribute used by the schema.</xs:documentation>
+                                    </xs:annotation>
+                                </xs:anyAttribute>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="externalReferences" type="bom:externalReferences" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document external references related to the BOM or
+                        to the project the BOM describes.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An identifier which can be used to reference the object elsewhere
+                    in the BOM. Every `bom-ref` must be unique within the BOM.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##other" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="tagsType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="tag" type="xs:normalizedString">
+                <xs:annotation>
+                    <xs:documentation>Textual strings that aid in discovery, search, and retrieval of the associated
+                        object. Tags often serve as a way to group or categorize similar or related objects by various
+                        attributes.
+
+                        Examples include:
+                        "json-parser", "object-persistence", "text-to-image", "translation", and "object-detection"
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="patentFamilyType">
+        <xs:annotation>
+            <xs:documentation>
+                A patent family is a group of related patent applications or granted patents that cover the same or similar invention. These patents are filed in multiple jurisdictions to protect the invention across different regions or countries. A patent family typically includes patents that share a common priority date, originating from the same initial application, and may vary slightly in scope or claims to comply with regional legal frameworks. Fields align with WIPO ST.96 standards where applicable.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="familyId" type="xs:string" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The unique identifier for the patent family, aligned with the `id` attribute in WIPO ST.96 v8.0's `PatentFamilyType`. Refer to [PatentFamilyType in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/PatentFamilyType.xsd).</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="priorityApplication" type="bom:priorityApplicationType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="members" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A collection of patents or applications that belong to this family, each identified by a `bom-ref` pointing to a patent object defined elsewhere in the BOM.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="ref" type="bom:refLinkType" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="externalReferences" type="bom:externalReferences" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An identifier which can be used to reference the object elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##other" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="patentType">
+        <xs:annotation>
+            <xs:documentation>
+                A patent is a legal instrument, granted by an authority, that confers certain rights over an invention for a specified period, contingent on public disclosure and adherence to relevant legal requirements. The summary information in this object is aligned with [WIPO ST.96](https://www.wipo.int/standards/en/st96/) principles where applicable.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="patentNumber" type="bom:patentNumberType" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The unique number assigned to the granted patent by the issuing authority. Aligned with `PatentNumber` in WIPO ST.96. Refer to [PatentNumber in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/PatentNumber.xsd).</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="applicationNumber" type="bom:patentNumberType" minOccurs="0"/>
+            <xs:element name="jurisdiction" type="bom:patentJurisdictionType" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="priorityApplication" type="bom:priorityApplicationType" minOccurs="0"/>
+            <xs:element name="publicationNumber" type="bom:patentNumberType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>This is the number assigned to a patent application once it is published. Patent applications are generally published 18 months after filing (unless an applicant requests non-publication). This number is distinct from the application number.
+
+                        Purpose: Identifies the publicly available version of the application.
+
+                        Format: Varies by jurisdiction, often similar to application numbers but includes an additional suffix indicating publication.
+
+                        Example:
+                        - US: US20240000123A1 (indicates the first publication of application US20240000123)
+                        - Europe: EP23123456A1 (first publication of European application EP23123456).
+
+                        WIPO ST.96 v8.0:
+                        - Publication Number field: https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/PublicationNumber.xsd</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="title" type="xs:string" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>The title of the patent, summarising the invention it protects. Aligned with `InventionTitle` in WIPO ST.96. Refer to [InventionTitle in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/InventionTitle.xsd).</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="abstract" type="xs:string" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>A brief summary of the invention described in the patent. Aligned with `Abstract` and `P` in WIPO ST.96. Refer to [Abstract in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/Abstract.xsd).</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="filingDate" type="xs:date" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>The date the patent application was filed with the jurisdiction. Aligned with `FilingDate` in WIPO ST.96. Refer to [FilingDate in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/FilingDate.xsd).</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="grantDate" type="xs:date" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>The date the patent was granted by the jurisdiction. Aligned with `GrantDate` in WIPO ST.96. Refer to [GrantDate in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/GrantDate.xsd).</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="patentExpirationDate" type="xs:date" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>The date the patent expires. Derived from grant or filing date according to jurisdiction-specific rules.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="patentLegalStatus" type="bom:patentLegalStatusEnum" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Indicates the current legal status of the patent or patent application, based on the WIPO ST.27 standard. This status reflects administrative, procedural, or legal events. Values include both active and inactive states and are useful for determining enforceability, procedural history, and maintenance status.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="patentAssignee" type="bom:organizationOrIndividualType" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>Organisations or individuals to whom the patent rights are assigned. Supports joint ownership.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="externalReferences" type="bom:externalReferences" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An identifier which can be used to reference the object elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##other" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="patentAssertionType">
+        <xs:annotation>
+            <xs:documentation>
+                An assertion linking a patent or patent family to a component or service. This allows expression of ownership, licensing, third-party claims, and other legal relationships.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="assertionType" type="bom:patentAssertionTypeEnum">
+                <xs:annotation>
+                    <xs:documentation>The type of assertion being made (e.g. ownership, license, third-party-claim, etc.).</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="patentRefs" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>A list of references (`bom-ref`) linking to patents or families associated with this assertion.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="bom-ref" type="xs:string" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="asserter">
+                <xs:annotation>
+                    <xs:documentation>The organisation, individual, or BOM reference asserting the patent claim.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:choice>
+                        <xs:element name="organization" type="bom:organizationalEntity"/>
+                        <xs:element name="contact" type="bom:organizationalContact"/>
+                        <xs:element name="ref" type="bom:refLinkType"/>
+                    </xs:choice>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="notes" type="xs:string" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Additional clarifications regarding the assertion, such as geographic or temporal constraints.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An identifier which can be used to reference the object elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##other" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:simpleType name="patentLegalStatusEnum">
+        <xs:annotation>
+            <xs:documentation>
+                The legal status of the patent, reflecting various administrative or judicial states a patent or application may be in. Aligned with concepts in WIPO ST.27.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="pending">
+                <xs:annotation><xs:documentation>The patent application has been filed but not yet examined or granted.</xs:documentation></xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="granted">
+                <xs:annotation><xs:documentation>The patent application has been examined and a patent has been issued.</xs:documentation></xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="revoked">
+                <xs:annotation><xs:documentation>The patent has been declared invalid through a legal or administrative process.</xs:documentation></xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="expired">
+                <xs:annotation><xs:documentation>The patent has reached the end of its enforceable term.</xs:documentation></xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="lapsed">
+                <xs:annotation><xs:documentation>The patent is no longer in force due to non-payment of maintenance fees or other requirements.</xs:documentation></xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="withdrawn">
+                <xs:annotation><xs:documentation>The patent application was voluntarily withdrawn by the applicant.</xs:documentation></xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="abandoned">
+                <xs:annotation><xs:documentation>The patent application was abandoned, often due to lack of action or response.</xs:documentation></xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="suspended">
+                <xs:annotation><xs:documentation>Processing of the patent application has been temporarily halted.</xs:documentation></xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="reinstated">
+                <xs:annotation><xs:documentation>A previously abandoned or lapsed patent has been reinstated.</xs:documentation></xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="opposed">
+                <xs:annotation><xs:documentation>The patent application or granted patent is under formal opposition proceedings.</xs:documentation></xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="terminated">
+                <xs:annotation><xs:documentation>The patent or application has been officially terminated.</xs:documentation></xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="invalidated">
+                <xs:annotation><xs:documentation>The patent has been invalidated, either in part or in full.</xs:documentation></xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="in-force">
+                <xs:annotation><xs:documentation>The granted patent is active and enforceable.</xs:documentation></xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="patentAssertionTypeEnum">
+        <xs:annotation>
+            <xs:documentation>
+                Specifies the type of assertion made about a patent or patent family. Enables documentation of legal, ownership, or usage-related claims.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="ownership">
+                <xs:annotation><xs:documentation>The manufacturer asserts ownership of the patent or patent family.</xs:documentation></xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="license">
+                <xs:annotation><xs:documentation>The manufacturer asserts they have a license to use the patent or patent family.</xs:documentation></xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="third-party-claim">
+                <xs:annotation><xs:documentation>A third party has asserted a claim or potential infringement against the manufacturer’s component or service.</xs:documentation></xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="standards-inclusion">
+                <xs:annotation><xs:documentation>The patent is part of a standard essential patent (SEP) portfolio relevant to the component or service.</xs:documentation></xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="prior-art">
+                <xs:annotation><xs:documentation>The manufacturer asserts the patent or patent family as prior art that invalidates another patent or claim.</xs:documentation></xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="exclusive-rights">
+                <xs:annotation><xs:documentation>The manufacturer asserts exclusive rights granted through a licensing agreement.</xs:documentation></xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="non-assertion">
+                <xs:annotation><xs:documentation>The manufacturer asserts they will not enforce the patent or patent family against certain uses or users.</xs:documentation></xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="research-or-evaluation">
+                <xs:annotation><xs:documentation>The patent or patent family is being used under a research or evaluation license.</xs:documentation></xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="patentNumberType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Za-z0-9][A-Za-z0-9\-/.() ]{0,28}[A-Za-z0-9]"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="patentJurisdictionType">
+        <xs:annotation>
+            <xs:documentation>
+                The jurisdiction or patent office where the priority application was filed, specified using WIPO ST.3 codes. Aligned with `IPOfficeCode` in ST.96. Refer to [IPOfficeCode in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Common/IPOfficeCode.xsd).
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z]{2}"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="patentFilingDateType">
+        <xs:annotation>
+            <xs:documentation>
+                The date the priority application was filed. Aligned with `FilingDate` in WIPO ST.96.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:date"/>
+    </xs:simpleType>
+
+    <xs:complexType name="priorityApplicationType">
+        <xs:annotation>
+            <xs:documentation>
+                The priorityApplication contains the essential data necessary to identify and reference an earlier patent filing for priority rights. In line with WIPO ST.96 guidelines, it includes the jurisdiction (office code), application number, and filing date-the three key elements that uniquely specify the priority application in a global patent context.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="applicationNumber" type="bom:patentNumberType" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="jurisdiction" type="bom:patentJurisdictionType" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="filingDate" type="bom:patentFilingDateType" minOccurs="1" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="citationsType">
+        <xs:sequence>
+            <xs:element name="citation" type="bom:citationType" minOccurs="1" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Details a specific attribution of data within the BOM to a contributing entity or process.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="citationType">
+        <xs:annotation>
+            <xs:documentation>
+                Details a specific attribution of data within the BOM to a contributing entity or process.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:annotation>
+                <xs:documentation>
+                    Exactly one of the "pointers" or "expressions" elements must be present.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:choice>
+                <xs:element name="pointers" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            One or more JSON Pointers(https://datatracker.ietf.org/doc/html/rfc6901) identifying the BOM fields to which the attribution applies.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="pointer" type="xs:string" minOccurs="1" maxOccurs="unbounded">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        A JSON Pointer(https://datatracker.ietf.org/doc/html/rfc6901) identifying the BOM field to which the attribution applies.
+                                        Users of other serialisation formats (e.g. XML) shall use the JSON Pointer format to ensure consistent field referencing across representations.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="expressions" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            One or more path expressions used to locate values within a BOM.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="expression" type="xs:string" minOccurs="1" maxOccurs="unbounded">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Specifies a path expression used to locate a value within a BOM. The expression syntax shall conform to the format of the BOM's serialisation.
+                                        Use [JSONPath](https://datatracker.ietf.org/doc/html/rfc9535) for JSON, [XPath](https://www.w3.org/TR/xpath/) for XML, and default to JSONPath for Protocol Buffers unless otherwise specified.
+                                        Implementers shall ensure the expression is valid within the context of the applicable serialisation format.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:choice>
+            <xs:element name="timestamp" type="xs:dateTime" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The date and time when the attribution was made or the information was supplied.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="attributedTo" type="bom:refLinkType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The `bom-ref` of an object, such as a component, service, tool, organisational entity, or person that supplied the cited information.
+                        At least one of the "attributedTo" or "process" elements must be present.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="process" type="bom:refLinkType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The `bom-ref` to a process (such as a formula, workflow, task, or step) defined in the `formulation` section that executed or generated the attributed data.
+                        At least one of the "attributedTo" or "process" elements must be present.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="note" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        An description or comment about the context or quality of the data attribution.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <!-- Attention:
+        This would be formal, if the support for XSD1.1's `assert` was properly implemented in validators and tools digesting XML.
+        <xs:assert vc:minVersion="1.1"
+                   id="requires_attributedTo_or_process"
+                   test="attributedTo or process">
+           At least one of the "attributedTo" or "process" elements must be present.
+        </xs:assert>
+        /-->
+        <xs:attribute name="bom-ref" type="bom:refType" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    An identifier which can be used to reference the object elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##other" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:element name="bom">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="metadata" type="bom:metadata" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Provides additional information about a BOM.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="components" type="bom:componentsType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>A list of software and hardware components.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="services" type="bom:servicesType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>A list of services. This may include microservices, function-as-a-service, and other types of network or intra-process services.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="externalReferences" type="bom:externalReferences" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Provides the ability to document external references related to the BOM or
+                            to the project the BOM describes.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="dependencies" type="bom:dependenciesType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Provides the ability to document dependency relationships.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="compositions" type="bom:compositionsType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Compositions describe constituent parts (including components, services, and dependency relationships) and their completeness. The completeness of vulnerabilities expressed in a BOM may also be described.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Provides the ability to document properties in a name/value store.
+                            This provides flexibility to include data not officially supported in the standard
+                            without having to use additional namespaces or create extensions. Property names
+                            of interest to the general public are encouraged to be registered in the
+                            CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                            Formal registration is optional.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="vulnerabilities" type="bom:vulnerabilitiesType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Vulnerabilities identified in components or services.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="annotations" type="bom:annotationsType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Comments made by people, organizations, or tools about any object with
+                            a bom-ref, such as components, services, vulnerabilities, or the BOM itself. Unlike
+                            inventory information, annotations may contain opinion or commentary from various
+                            stakeholders. Annotations may be inline (with inventory) or externalized via BOM-Link,
+                            and may optionally be signed.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="formulation" type="bom:formulationType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Describes the formulation of any referencable object within the BOM,
+                            including components, services, metadata, declarations, or the BOM itself. This may
+                            encompass how the object was created, assembled, deployed, tested, certified, or otherwise
+                            brought into its present form. Common examples include software build pipelines,
+                            deployment processes, AI/ML model training, cryptographic key generation or certification,
+                            and third-party audits. Processes are modeled using declared and observed formulas,
+                            composed of workflows, tasks, and individual steps.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="declarations" type="bom:declarationsType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The list of declarations which describe the conformance to standards. Each declaration may
+                            include attestations, claims, and evidence.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="definitions" type="bom:definitionsType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            A collection of reusable objects that are defined and may be used elsewhere in the BOM.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="citations" type="bom:citationsType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>A collection of attributions indicating which entity supplied information for specific fields within the BOM.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Allows any undeclared elements as long as the elements are placed in a different namespace.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:any>
+            </xs:sequence>
+            <xs:attribute name="version" type="xs:positiveInteger" default="1">
+                <xs:annotation>
+                    <xs:documentation>Whenever an existing BOM is modified, either manually or through automated
+                        processes, the version of the BOM SHOULD be incremented by 1. When a system is presented with
+                        multiple BOMs with identical serial numbers, the system SHOULD use the most recent version of the BOM.
+                        The default version is '1'.</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="serialNumber" type="bom:urnUuid">
+                <xs:annotation>
+                    <xs:documentation>Every BOM generated SHOULD have a unique serial number, even if the contents of
+                        the BOM have not changed over time. If specified, the serial number must conform to RFC-4122.
+                        Use of serial numbers are recommended.</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:anyAttribute namespace="##any" processContents="lax">
+                <xs:annotation>
+                    <xs:documentation>User-defined attributes may be used on this element as long as they
+                        do not have the same name as an existing attribute used by the schema.</xs:documentation>
+                </xs:annotation>
+            </xs:anyAttribute>
+        </xs:complexType>
+        <xs:unique name="bom-ref">
+            <xs:selector xpath=".//*"/>
+            <xs:field xpath="@bom-ref"/>
+        </xs:unique>
+    </xs:element>
+</xs:schema>

--- a/validate_json_test.go
+++ b/validate_json_test.go
@@ -30,6 +30,7 @@ var jsonSchemaFiles = map[SpecVersion]string{
 	SpecVersion1_4: "file://./schema/bom-1.4.schema.json",
 	SpecVersion1_5: "file://./schema/bom-1.5.schema.json",
 	SpecVersion1_6: "file://./schema/bom-1.6.schema.json",
+	SpecVersion1_7: "file://./schema/bom-1.7.schema.json",
 }
 
 type jsonValidator struct{}

--- a/validate_xml_test.go
+++ b/validate_xml_test.go
@@ -32,6 +32,7 @@ var xmlSchemaFiles = map[SpecVersion]string{
 	SpecVersion1_4: "./schema/bom-1.4.xsd",
 	SpecVersion1_5: "./schema/bom-1.5.xsd",
 	SpecVersion1_6: "./schema/bom-1.6.xsd",
+	SpecVersion1_7: "./schema/bom-1.7.xsd",
 }
 
 var xsdValidateInitOnce sync.Once


### PR DESCRIPTION
This implementation adds:
- Citations for data provenance and attribution
- Patent information and assertions
- Enhanced Cryptography Bill of Materials (CBOM) features
- Traffic Light Protocol (TLP) distribution constraints
- IKEv2 transform types for protocol properties
- Extended certificate lifecycle management
- New cryptographic asset tracking capabilities

Breaking changes:
- Default BOM version changed from 1.6 to 1.7
- NewBOM() now creates version 1.7 BOMs by default

Changes by file:

cyclonedx.go:
- Add SpecVersion1_7 constant
- Add BOM.Citations field for data attribution
- Add Component.IsExternal, Component.PatentAssertions, Component.VersionRange
- Add Service.PatentAssertions field
- Add Metadata.DistributionConstraints field
- Add ExternalReference.Properties field
- Enhance CertificateProperties with 11 new fields:
  * SerialNumber, CertificateFileExtension, Fingerprint
  * CertificateState, CertificateExtensions
  * RelatedCryptographicAssets
  * CreationDate, ActivationDate, DeactivationDate
  * RevocationDate, DestructionDate
- Enhance CryptoAlgorithmProperties with AlgorithmFamily, EllipticCurve
- Enhance RelatedCryptoMaterialProperties with Fingerprint, RelatedCryptographicAssets
- Enhance CryptoProtocolProperties with RelatedCryptographicAssets
- Enhance CipherSuite with TLSGroups, TLSSignatureSchemes
- Add new types:
  * Citation (8 fields: BOMRef, Pointers, Expressions, Timestamp, AttributedTo, Process, Note, Signature)
  * Patent (14 fields: BOMRef, PatentNumber, ApplicationNumber, Jurisdiction, PriorityApplication, PublicationNumber, Title, Abstract, FilingDate, GrantDate, PatentExpirationDate, PatentLegalStatus, PatentAssignee, ExternalReferences)
  * PatentFamily (5 fields: BOMRef, FamilyID, PriorityApplication, Members, ExternalReferences)
  * PatentAssertion (5 fields: BOMRef, PatentRefs, AssertionType, Asserter, Notes)
  * PatentAssertionType with 8 enum values
  * DistributionConstraints with TLP field
  * TLPClassification with 5 levels (Clear, Green, Amber, Amber+Strict, Red)
  * RelatedCryptographicAsset (Type, Ref)
  * CertificateState with predefined and custom state support
  * CertificateStateType with 6 enum values (pre-activation, active, suspended, deactivated, revoked, destroyed)
  * CertificateExtension with predefined and custom extension support
  * CertificateExtensionName with 10 common extensions
  * IKEv2TransformTypes (Encr, PRF, Integ, KE, ESN, Auth)
  * IKEv2Auth, IKEv2Enc, IKEv2Integ, IKEv2Ke, IKEv2Prf structs
- Add hash algorithms: HashAlgoStreebog256, HashAlgoStreebog512
- Remove unused PatentLegalEvent type

cyclonedx_json.go:
- Add SpecVersion1_7 to jsonSchemas map
- Add 1.7 case to BOM.UnmarshalJSON

cyclonedx_xml.go:
- Add SpecVersion1_7 to xmlNamespaces map
- Add 1.7 case to BOM.UnmarshalXML

cyclonedx_string.go:
- Regenerate with SpecVersion1_7 string representation

convert.go:
- Add version conversion for BOM.Citations (< 1.7)
- Add version conversion for Metadata.DistributionConstraints (< 1.7)
- Add version conversion for Component.IsExternal, PatentAssertions, VersionRange (< 1.7)
- Add version conversion for Service.PatentAssertions (< 1.7)
- Add version conversion for ExternalReference.Properties (< 1.7)
- Add convertCryptoProperties function for all CBOM 1.7 fields:
  * CryptoAlgorithmProperties.AlgorithmFamily, EllipticCurve
  * CertificateProperties (11 fields)
  * RelatedCryptoMaterialProperties.Fingerprint, RelatedCryptographicAssets
  * CryptoProtocolProperties.RelatedCryptographicAssets
  * CipherSuite.TLSGroups, TLSSignatureSchemes
- Add hash algorithm version support for Streebog algorithms (>= 1.7)

example_test.go:
- Update Example_encode expected output from 1.6 to 1.7 namespace

encode_test.go:
- Update all test expectations from 1.6 to 1.7

Addresses issue #247 