### PR TITLE
Support for `concludedValue` in evidence/identity

### DIFF
--- a/cyclonedx.go
+++ b/cyclonedx.go
@@ -642,10 +642,11 @@ type Evidence struct {
 }
 
 type EvidenceIdentity struct {
-	Field      EvidenceIdentityFieldType `json:"field,omitempty" xml:"field,omitempty"`
-	Confidence *float32                  `json:"confidence,omitempty" xml:"confidence,omitempty"`
-	Methods    *[]EvidenceIdentityMethod `json:"methods,omitempty" xml:"methods>method,omitempty"`
-	Tools      *[]BOMReference           `json:"tools,omitempty" xml:"tools>tool,omitempty"`
+	Field          EvidenceIdentityFieldType `json:"field,omitempty" xml:"field,omitempty"`
+	Confidence     *float32                  `json:"confidence,omitempty" xml:"confidence,omitempty"`
+	ConcludedValue string                    `json:"concludedValue,omitempty" xml:"concludedValue,omitempty"`
+	Methods        *[]EvidenceIdentityMethod `json:"methods,omitempty" xml:"methods>method,omitempty"`
+	Tools          *[]BOMReference           `json:"tools,omitempty" xml:"tools>tool,omitempty"`
 }
 
 type EvidenceIdentityFieldType string

--- a/cyclonedx_json_test.go
+++ b/cyclonedx_json_test.go
@@ -198,8 +198,9 @@ func TestEvidence_MarshalJSON(t *testing.T) {
 		evidence := Evidence{
 			Identity: &[]EvidenceIdentity{
 				{
-					Field:      EvidenceIdentityFieldTypePURL,
-					Confidence: toPointer(t, float32(1)),
+					Field:          EvidenceIdentityFieldTypePURL,
+					Confidence:     toPointer(t, float32(1)),
+					ConcludedValue: "pkg:maven/com.google.code.findbugs/findbugs-project@3.0.0",
 					Methods: &[]EvidenceIdentityMethod{
 						{
 							Technique:  "filename",
@@ -220,7 +221,7 @@ func TestEvidence_MarshalJSON(t *testing.T) {
 		}
 		jsonBytes, err := json.Marshal(evidence)
 		require.NoError(t, err)
-		require.Equal(t, `{"identity":[{"field":"purl","confidence":1,"methods":[{"technique":"filename","confidence":0.1,"value":"findbugs-project-3.0.0.jar"},{"technique":"ast-fingerprint","confidence":0.9,"value":"61e4bc08251761c3a73b606b9110a65899cb7d44f3b14c81ebc1e67c98e1d9ab"}],"tools":["bom-ref-of-tool-that-performed-analysis"]}]}`, string(jsonBytes))
+		require.Equal(t, `{"identity":[{"field":"purl","confidence":1,"concludedValue":"pkg:maven/com.google.code.findbugs/findbugs-project@3.0.0","methods":[{"technique":"filename","confidence":0.1,"value":"findbugs-project-3.0.0.jar"},{"technique":"ast-fingerprint","confidence":0.9,"value":"61e4bc08251761c3a73b606b9110a65899cb7d44f3b14c81ebc1e67c98e1d9ab"}],"tools":["bom-ref-of-tool-that-performed-analysis"]}]}`, string(jsonBytes))
 	})
 }
 

--- a/testdata/snapshots/cyclonedx-go-TestRoundTripJSON-func1-valid-evidence.json
+++ b/testdata/snapshots/cyclonedx-go-TestRoundTripJSON-func1-valid-evidence.json
@@ -23,6 +23,7 @@
           {
             "field": "purl",
             "confidence": 1,
+            "concludedValue": "pkg:maven/com.google.code.findbugs/findbugs-project@3.0.0",
             "methods": [
               {
                 "technique": "filename",

--- a/testdata/snapshots/cyclonedx-go-TestRoundTripXML-func1-valid-evidence.xml
+++ b/testdata/snapshots/cyclonedx-go-TestRoundTripXML-func1-valid-evidence.xml
@@ -16,6 +16,7 @@
         <identity>
           <field>purl</field>
           <confidence>1</confidence>
+          <concludedValue>pkg:maven/com.google.code.findbugs/findbugs-project@3.0.0</concludedValue>
           <methods>
             <method>
               <technique>filename</technique>

--- a/testdata/valid-evidence.json
+++ b/testdata/valid-evidence.json
@@ -23,6 +23,7 @@
           {
             "field": "purl",
             "confidence": 1,
+            "concludedValue": "pkg:maven/com.google.code.findbugs/findbugs-project@3.0.0",
             "methods": [
               {
                 "technique": "filename",
@@ -58,7 +59,6 @@
         "callstack": {
           "frames": [
             {
-
               "package": "com.apache.logging.log4j.core",
               "module": "Logger.class",
               "function": "logMessage",

--- a/testdata/valid-evidence.xml
+++ b/testdata/valid-evidence.xml
@@ -16,6 +16,7 @@
                 <identity>
                     <field>purl</field>
                     <confidence>1</confidence>
+                    <concludedValue>pkg:maven/com.google.code.findbugs/findbugs-project@3.0.0</concludedValue>
                     <methods>
                         <method>
                             <technique>filename</technique>


### PR DESCRIPTION
This adds missing support for serialization and deserialization of data that uses the evidence.identity[].concludedValue field which was introduced in CycloneDX 1.6.

https://cyclonedx.org/docs/1.6/json/#components_items_evidence_identity_oneOf_i0_items_concludedValue