### PR TITLE
New BOM with Spec Version

### DIFF
--- a/cyclonedx.go
+++ b/cyclonedx.go
@@ -131,11 +131,15 @@ type BOM struct {
 }
 
 func NewBOM() *BOM {
+	return NewBOMWithSpecVersion(SpecVersion1_7)
+}
+
+func NewBOMWithSpecVersion(specVersion SpecVersion) *BOM {
 	return &BOM{
-		JSONSchema:  jsonSchemas[SpecVersion1_7],
-		XMLNS:       xmlNamespaces[SpecVersion1_7],
+		JSONSchema:  jsonSchemas[specVersion],
+		XMLNS:       xmlNamespaces[specVersion],
 		BOMFormat:   BOMFormat,
-		SpecVersion: SpecVersion1_7,
+		SpecVersion: specVersion,
 		Version:     1,
 	}
 }


### PR DESCRIPTION
## `feat: add NewBOMWithSpecVersion for configurable BOM spec version`

## Summary
Adds `NewBOMWithSpecVersion(specVersion SpecVersion)` so callers can create a BOM with the correct JSON schema, XML namespace, and `specVersion` for any supported CycloneDX spec. `NewBOM()` is unchanged in behavior and still defaults to CycloneDX 1.7 by delegating to the new helper.

## Changes
- Add `NewBOMWithSpecVersion(specVersion SpecVersion) *BOM` in `cyclonedx.go`
- Refactor `NewBOM()` to call `NewBOMWithSpecVersion(SpecVersion1_7)` instead of inlining field initialization
- Initialize `JSONSchema`, `XMLNS`, and `SpecVersion` from the `specVersion` argument via existing `jsonSchemas` / `xmlNamespaces` maps

## Notes
- Non-breaking: `NewBOM()` behavior is preserved