### PR TITLE
fix: set BOMFormat when decoding a BOM from XML

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -58,6 +58,12 @@ func (x xmlBOMDecoder) Decode(bom *BOM) error {
 		return err
 	}
 
+	// BOMFormat is not represented in XML (it is a JSON-only field), so it is
+	// never populated by the unmarshaller. Set it explicitly so that a BOM
+	// decoded from XML and then re-encoded to JSON carries the required
+	// "bomFormat": "CycloneDX" value instead of an empty string.
+	bom.BOMFormat = BOMFormat
+
 	for specVersion, xmlNs := range xmlNamespaces {
 		if xmlNs == bom.XMLNS {
 			bom.SpecVersion = specVersion

--- a/decode_test.go
+++ b/decode_test.go
@@ -18,6 +18,7 @@
 package cyclonedx
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -82,5 +83,29 @@ func TestXmlBOMDecoder_Decode(t *testing.T) {
 				require.Equal(t, tc.specVersion, bom.SpecVersion)
 			})
 		}
+	})
+
+	// BOMFormat is a JSON-only field that is never present in XML input. The XML
+	// decoder must set it so a BOM decoded from XML and re-encoded to JSON keeps
+	// the required "bomFormat": "CycloneDX" value. See issue #245.
+	t.Run("ShouldSetBOMFormat", func(t *testing.T) {
+		bomContent := `<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6"
+    serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79"
+    version="1">
+</bom>`
+
+		var bom BOM
+		err := NewBOMDecoder(strings.NewReader(bomContent), BOMFileFormatXML).Decode(&bom)
+		require.NoError(t, err)
+		require.Equal(t, BOMFormat, bom.BOMFormat)
+
+		// Re-encoding the XML-decoded BOM to JSON must emit a valid bomFormat,
+		// not an empty string.
+		buf := bytes.Buffer{}
+		err = NewBOMEncoder(&buf, BOMFileFormatJSON).SetPretty(true).Encode(&bom)
+		require.NoError(t, err)
+		assert.Contains(t, buf.String(), `"bomFormat": "CycloneDX"`)
+		assert.NotContains(t, buf.String(), `"bomFormat": ""`)
 	})
 }


### PR DESCRIPTION
Fixes #245

## Problem

Decoding a CycloneDX BOM from XML leaves `BOM.BOMFormat` empty. Because `bomFormat` is a JSON-only field (`xml:"-"`), the XML unmarshaller never populates it, and unlike the spec-version handling the decoder did not set it afterwards. Re-encoding such a BOM to JSON then produces an invalid document with `"bomFormat": ""` instead of the required `"CycloneDX"`.

Minimal repro (from the issue):

```xml
<?xml version="1.0" encoding="UTF-8"?>
<bom xmlns="http://cyclonedx.org/schema/bom/1.6"
    serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79"
    version="1">
</bom>
```

Decoding this XML and re-encoding to JSON, before the fix:

```json
{
  "bomFormat": "",
  "specVersion": "1.6",
  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
  "version": 1
}
```

## Root cause

`xmlBOMDecoder.Decode` (in `decode.go`) normalizes `SpecVersion` from the XML namespace after unmarshalling but never sets `BOMFormat`. The JSON path keeps `bomFormat` because it is present in JSON input; XML input has no equivalent, so the field stays at its zero value.

## Fix

Set `bom.BOMFormat = BOMFormat` (the `"CycloneDX"` constant) right after the XML unmarshal, alongside the existing `SpecVersion` normalization. This is the same value any valid BOM carries, so it does not change any otherwise-valid field. `SpecVersion` is already handled; no other JSON-only normalization is needed.

After the fix the same round trip emits:

```json
{
  "bomFormat": "CycloneDX",
  "specVersion": "1.6",
  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
  "version": 1
}
```

## Tests

Added a `ShouldSetBOMFormat` subtest to `TestXmlBOMDecoder_Decode` that decodes the issue's XML, asserts `BOMFormat` is set, and re-encodes to JSON to confirm the output contains `"bomFormat": "CycloneDX"` and not `"bomFormat": ""`. The test fails without the one-line source change and passes with it. `go build ./...`, `go vet ./...`, and the full `go test ./...` suite are green.
