### PR TITLE
fix: preserve author when downgrading components below 1.6

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -174,6 +174,9 @@ func componentConverter(specVersion SpecVersion) func(*Component) {
 			c.SWHID = nil
 			c.OmniborID = nil
 			c.Manufacturer = nil
+			if c.Author == "" && c.Authors != nil && len(*c.Authors) > 0 {
+				c.Author = (*c.Authors)[0].Name
+			}
 			c.Authors = nil
 			c.Tags = nil
 		}

--- a/convert_test.go
+++ b/convert_test.go
@@ -244,6 +244,42 @@ func Test_convertAuthors(t *testing.T) {
 
 		assert.Nil(t, (*bom.Components)[0].Authors)
 	})
+
+	t.Run("collapse into deprecated author below 1.6", func(t *testing.T) {
+		bom := NewBOM()
+		bom.Components = &[]Component{
+			{
+				Name: "foo",
+				Authors: &[]OrganizationalContact{
+					{Name: "Jane Doe"},
+					{Name: "John Doe"},
+				},
+			},
+		}
+
+		bom.convert(SpecVersion1_5)
+
+		assert.Nil(t, (*bom.Components)[0].Authors)
+		assert.Equal(t, "Jane Doe", (*bom.Components)[0].Author)
+	})
+
+	t.Run("keep existing author when both set below 1.6", func(t *testing.T) {
+		bom := NewBOM()
+		bom.Components = &[]Component{
+			{
+				Name:   "foo",
+				Author: "Existing Author",
+				Authors: &[]OrganizationalContact{
+					{Name: "Jane Doe"},
+				},
+			},
+		}
+
+		bom.convert(SpecVersion1_5)
+
+		assert.Nil(t, (*bom.Components)[0].Authors)
+		assert.Equal(t, "Existing Author", (*bom.Components)[0].Author)
+	})
 }
 
 func Test_convertTrustZone(t *testing.T) {


### PR DESCRIPTION
Fixes #190.

Downgrading a component to a spec version below 1.6 clears the `authors` field, since it doesn't exist in the earlier schemas. If the deprecated single `author` string wasn't set, the author info was dropped entirely on the way down.

This collapses the first entry of `authors` into the deprecated `author` field before clearing `authors`, but only when `author` isn't already set so an explicit value is never clobbered. That follows what you outlined in the issue ("reduce the array of authors to a single string, and populate author with that instead"). It also covers the tool-components half of the report: components under `metadata.tools` recurse through the same `componentConverter`, so their `authors` are reduced the same way now rather than ending up in a 1.5 BOM.

Added subtests under `Test_convertAuthors`: one for the collapse on a 1.5 downgrade, one confirming an existing `author` is preserved when both are set. The collapse case fails without the change and passes with it; the existing case still passes. `go test ./...` and `go vet ./...` are clean.

Happy to adjust if you'd prefer something other than first-author-wins. Thanks!