### PR TITLE
xml: fix DataClassification unmarshal over-reading past its element

### DIFF
--- a/cyclonedx_xml.go
+++ b/cyclonedx_xml.go
@@ -1120,7 +1120,7 @@ func (dc *DataClassification) UnmarshalXML(d *xml.Decoder, start xml.StartElemen
 			}
 
 		case xml.EndElement:
-			if el.Name.Local == "dataflow" {
+			if el.Name == start.Name {
 				return nil
 			}
 		}

--- a/decode_test.go
+++ b/decode_test.go
@@ -84,3 +84,38 @@ func TestXmlBOMDecoder_Decode(t *testing.T) {
 		}
 	})
 }
+
+func TestXmlBOMDecoder_Decode_DataClassificationEndTag(t *testing.T) {
+	// DataClassification is bound both to <dataflow> and, via
+	// EvidenceData.Classification (xml:"data>classification"), to
+	// <classification>. Its custom UnmarshalXML must terminate on its own end
+	// tag rather than a hardcoded </dataflow>; otherwise decoding a
+	// <classification> element reads past the element and consumes the rest of
+	// the document, dropping anything that follows.
+	input := `<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <declarations>
+    <evidence>
+      <evidence>
+        <data>
+          <data>
+            <classification>Public</classification>
+          </data>
+        </data>
+      </evidence>
+    </evidence>
+  </declarations>
+  <components>
+    <component type="library">
+      <name>acme-lib</name>
+    </component>
+  </components>
+</bom>`
+
+	var bom BOM
+	err := NewBOMDecoder(strings.NewReader(input), BOMFileFormatXML).Decode(&bom)
+	require.NoError(t, err)
+	require.NotNil(t, bom.Components)
+	require.Len(t, *bom.Components, 1)
+	assert.Equal(t, "acme-lib", (*bom.Components)[0].Name)
+}


### PR DESCRIPTION
`DataClassification.UnmarshalXML` terminates its token loop on `</dataflow>` (a hardcoded literal), but the same type is also bound to the `<classification>` element via `EvidenceData.Classification` (`xml:"data>classification"`), not only `<dataflow>` (`xml:"data>dataflow"`). When decoding a `<classification>` element the loop never sees `</dataflow>`, so it keeps reading past its own end tag and consumes following tokens until `io.EOF`, which surfaces as a decode error. Any BOM that carries an evidence-data classification then fails to decode, and content after it is silently dropped.

The fix compares against the element the unmarshaler was actually called for (`start.Name`) instead of a literal, which is the usual depth-0 termination pattern for a custom `UnmarshalXML`. Child elements are still consumed by the inner loops, so the first top-level end element is always this element's own close.

I added a round-trip test with a 1.6 BOM whose declarations carry an evidence-data classification followed by a components block: it fails to decode with `EOF` before the change and decodes cleanly (classification parsed, components preserved) after.