### PR TITLE
Strip fields newer than the target spec version when downgrading

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -176,6 +176,7 @@ func componentConverter(specVersion SpecVersion) func(*Component) {
 			c.Manufacturer = nil
 			c.Authors = nil
 			c.Tags = nil
+			c.CryptoProperties = nil
 		}
 
 		if specVersion < SpecVersion1_7 {
@@ -253,6 +254,10 @@ func convertCompositions(comps *[]Composition, specVersion SpecVersion) {
 
 	for i := range *comps {
 		comp := &(*comps)[i]
+		if specVersion < SpecVersion1_5 {
+			comp.BOMRef = ""
+			comp.Vulnerabilities = nil
+		}
 		if !specVersion.supportsCompositionAggregate(comp.Aggregate) {
 			comp.Aggregate = CompositionAggregateUnknown
 		}
@@ -515,6 +520,10 @@ func convertVulnerabilities(vulns *[]Vulnerability, specVersion SpecVersion) {
 			vuln.ProofOfConcept = nil
 			vuln.Rejected = ""
 			vuln.Workaround = ""
+			if vuln.Analysis != nil {
+				vuln.Analysis.FirstIssued = ""
+				vuln.Analysis.LastUpdated = ""
+			}
 		}
 
 		if specVersion < SpecVersion1_6 {

--- a/convert_test.go
+++ b/convert_test.go
@@ -18,6 +18,8 @@
 package cyclonedx
 
 import (
+	"bytes"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -294,5 +296,67 @@ func Test_convertTags(t *testing.T) {
 
 		assert.Nil(t, bom.Metadata.Component.Tags)
 		assert.Nil(t, (*bom.Components)[0].Tags)
+	})
+}
+
+func Test_convert_stripsFieldsNewerThanTargetSpec(t *testing.T) {
+	// Downgrading a BOM must not leave behind fields that were only introduced
+	// in a later spec version - the resulting document has to validate against
+	// the target version's schema. These cases each reproduce a field that was
+	// carried over unchanged and rejected by the older schema.
+
+	decode := func(t *testing.T, path string) BOM {
+		f, err := os.Open(path)
+		require.NoError(t, err)
+		defer f.Close()
+		var bom BOM
+		require.NoError(t, NewBOMDecoder(f, BOMFileFormatJSON).Decode(&bom))
+		return bom
+	}
+
+	encodeVersion := func(t *testing.T, bom *BOM, version SpecVersion) []byte {
+		var buf bytes.Buffer
+		require.NoError(t, NewBOMEncoder(&buf, BOMFileFormatJSON).EncodeVersion(bom, version))
+		return buf.Bytes()
+	}
+
+	t.Run("cryptoProperties removed below 1.6", func(t *testing.T) {
+		bom := decode(t, "./testdata/valid-cryptographic-asset.json")
+		out := encodeVersion(t, &bom, SpecVersion1_5)
+		assertValidBOM(t, out, BOMFileFormatJSON, SpecVersion1_5)
+
+		bom = decode(t, "./testdata/valid-cryptographic-asset.json")
+		bom.convert(SpecVersion1_5)
+		for _, c := range *bom.Components {
+			assert.Nil(t, c.CryptoProperties)
+		}
+	})
+
+	t.Run("composition bom-ref and vulnerabilities removed below 1.5", func(t *testing.T) {
+		bom := decode(t, "./testdata/valid-compositions.json")
+		out := encodeVersion(t, &bom, SpecVersion1_4)
+		assertValidBOM(t, out, BOMFileFormatJSON, SpecVersion1_4)
+
+		bom = decode(t, "./testdata/valid-compositions.json")
+		bom.convert(SpecVersion1_4)
+		for _, comp := range *bom.Compositions {
+			assert.Empty(t, comp.BOMRef)
+			assert.Nil(t, comp.Vulnerabilities)
+		}
+	})
+
+	t.Run("vulnerability analysis firstIssued and lastUpdated removed below 1.5", func(t *testing.T) {
+		bom := decode(t, "./testdata/valid-vulnerability.json")
+		out := encodeVersion(t, &bom, SpecVersion1_4)
+		assertValidBOM(t, out, BOMFileFormatJSON, SpecVersion1_4)
+
+		bom = decode(t, "./testdata/valid-vulnerability.json")
+		bom.convert(SpecVersion1_4)
+		for _, vuln := range *bom.Vulnerabilities {
+			if vuln.Analysis != nil {
+				assert.Empty(t, vuln.Analysis.FirstIssued)
+				assert.Empty(t, vuln.Analysis.LastUpdated)
+			}
+		}
 	})
 }


### PR DESCRIPTION
`BOM.convert` already clears most fields that were introduced after the target spec version, but a few slip through, so encoding some BOMs to an older version produces output that fails that version's own JSON schema.

Three cases:
- `component.cryptoProperties` (added in 1.6) survives a downgrade below 1.6. `convertCryptoProperties` only trims its inner 1.7 fields, so a downgraded CBOM keeps the whole `cryptoProperties` object.
- `composition.bom-ref` and `composition.vulnerabilities` (added in 1.5) survive a downgrade below 1.5, where `convertCompositions` only normalized the aggregate.
- `vulnerability.analysis.firstIssued` and `lastUpdated` (added in 1.5) survive a downgrade below 1.5.

Each is now cleared next to the fields the surrounding code already clears for the same versions (`Tags`, `ProofOfConcept`, and the rest). This is the same class as #248.

`Test_convert_stripsFieldsNewerThanTargetSpec` decodes the existing `valid-cryptographic-asset` / `valid-compositions` / `valid-vulnerability` fixtures, re-encodes them at the older version, and validates the result against that version's bundled schema with the existing `assertValidBOM` helper. Each subtest fails on master (the schema rejects the leftover field) and passes with the change.

`go test ./...` and `go vet ./...` are clean.