### PR TITLE
Encode evidence identity as a single object when downgrading below 1.6

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -219,17 +219,20 @@ func convertEvidence(c *Component, specVersion SpecVersion) {
 	}
 
 	if specVersion < SpecVersion1_6 {
-		// Spec version 1.5 uses only one Identity.
+		// Spec version 1.5 defines identity as a single object, not an array.
 		// cf. https://cyclonedx.org/docs/1.5/json/#components_items_evidence_identity
 		if c.Evidence.Identity != nil && c.Evidence.Identity.Identities != nil {
 			ids := *c.Evidence.Identity.Identities
-			ids = ids[:1]
-			c.Evidence.Identity = &EvidenceIdentityChoice{Identities: &ids}
-		}
-		if c.Evidence.Identity != nil && c.Evidence.Identity.Identities != nil {
-			for i := range *c.Evidence.Identity.Identities {
-				(*c.Evidence.Identity.Identities)[i].ConcludedValue = ""
+			if len(ids) > 0 {
+				first := ids[0]
+				c.Evidence.Identity = &EvidenceIdentityChoice{Identity: &first}
+			} else {
+				c.Evidence.Identity = nil
 			}
+		}
+		if c.Evidence.Identity != nil && c.Evidence.Identity.Identity != nil {
+			// concludedValue was introduced in 1.6.
+			c.Evidence.Identity.Identity.ConcludedValue = ""
 		}
 		if c.Evidence.Occurrences != nil {
 			for i := range *c.Evidence.Occurrences {

--- a/convert_test.go
+++ b/convert_test.go
@@ -65,7 +65,8 @@ func Test_componentConverter_convertEvidence(t *testing.T) {
 			Evidence: &Evidence{
 				Identity: &EvidenceIdentityChoice{Identities: &[]EvidenceIdentity{
 					{
-						Field: EvidenceIdentityFieldTypePURL,
+						Field:          EvidenceIdentityFieldTypePURL,
+						ConcludedValue: "pkg:generic/acme@1.0.0",
 					},
 					{
 						Field: EvidenceIdentityFieldTypeName,
@@ -86,7 +87,14 @@ func Test_componentConverter_convertEvidence(t *testing.T) {
 
 		convert(&comp)
 
-		require.Len(t, *comp.Evidence.Identity.Identities, 1)
+		// 1.5 defines identity as a single object, so the array must collapse to
+		// the first entry stored as a single Identity (not Identities); otherwise
+		// the encoded document fails the 1.5 schema (identity must be an object).
+		require.NotNil(t, comp.Evidence.Identity.Identity)
+		require.Nil(t, comp.Evidence.Identity.Identities)
+		assert.Equal(t, EvidenceIdentityFieldTypePURL, comp.Evidence.Identity.Identity.Field)
+		// concludedValue was introduced in 1.6 and must be dropped.
+		assert.Zero(t, comp.Evidence.Identity.Identity.ConcludedValue)
 		require.Len(t, *comp.Evidence.Occurrences, 1)
 		occ := (*comp.Evidence.Occurrences)[0]
 		assert.Nil(t, occ.Line)


### PR DESCRIPTION
Downgrading a BOM whose `component.evidence.identity` is an array (the form added in 1.6) to spec 1.5 or lower still emitted an array, but the 1.5 schema declares `componentEvidence.identity` as a single object. The downgraded document then fails the bundled 1.5 schema:

```
components.0.evidence.identity: Invalid type. Expected: object, given: array
```

`convertEvidence` already truncated the array to its first entry, but stored it back in `Identities` (the array field) rather than `Identity` (the single object), so the marshaler serialized an array.

What changed:
- `convertEvidence`: on a downgrade below 1.6, keep the first identity as a single `Identity` object instead of a one-element `Identities` array, and clear `concludedValue` (1.6+) on it. An empty `Identities` now clears the identity rather than panicking on `ids[:1]`.
- `Test_componentConverter_convertEvidence`: assert the 1.5 result is a single `Identity` (not `Identities`) with `concludedValue` dropped.

Same class as #248 (a field left in place made the downgraded document fail the 1.5 schema). Related to #192.

Checked:
- `go test .`
- `go vet .`, `gofmt -l`
