### PR TITLE
chore: refresh goreleaser setup

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # tag=v7.2.3
       with:
-        version: latest
+        version: "~> v2"
         args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 builds:
 # This is a library project, we don't want to build any binaries.
 # Building and testing is performed in the CI workflow
@@ -12,13 +14,13 @@ source:
 sboms:
 - artifacts: source
   documents:
-  - "${artifact}.cdx.sbom"
+  - "${artifact}.cdx.json"
   cmd: cyclonedx-gomod
   args: [ "mod", "-licenses", "-json", "-output", "$document", "./.." ]
 
 milestones:
 - name_template: "{{ .Tag }}"
-  close: true
+  close: false
 
 changelog:
   use: github


### PR DESCRIPTION
Adds config version, pins goreleaser version to v2, and fixes SBOM naming to follow CycloneDX conventions.